### PR TITLE
Gather Inputs pipeline step

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "chemicals",
         "click-loguru",
         "dask",
+        "deprecation",
         "distributed",
         "dill",
         "dpath",

--- a/src/pymorize/gather_inputs.py
+++ b/src/pymorize/gather_inputs.py
@@ -300,13 +300,13 @@ def gather_inputs(config: dict) -> dict:
         if year_end is not None:
             year_end = int(year_end)
         for input_pattern in input_patterns:
-            if _validate_rule_has_marked_regex(input_pattern):
-                pattern = re.compile(input_pattern["pattern"])
+            if _validate_rule_has_marked_regex(rule):
+                pattern = re.compile(rule["pattern"])
             else:
                 # FIXME(PG): This needs to be thought through...
                 # If the pattern is not marked, use the environment variable
                 pattern = _input_pattern_from_env(config)
-            files = _input_files_in_path(input_pattern["path"], pattern)
+            files = _input_files_in_path(input_pattern, pattern)
             files = _resolve_symlinks(files)
             if year_start is not None and year_end is not None:
                 files = _filter_by_year(files, pattern, year_start, year_end)

--- a/src/pymorize/gather_inputs.py
+++ b/src/pymorize/gather_inputs.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 from typing import List
 
+import deprecation
 import dpath
 
 _PATTERN_ENV_VAR_NAME_ADDR = "/pymorize/pattern_env_var_name"
@@ -213,6 +214,7 @@ def _validate_rule_has_marked_regex(
     return all(re.search(rf"\(\?P<{mark}>", pattern) for mark in required_marks)
 
 
+@deprecation.deprecated(details="Use load_mfdataset in your pipeline instead!")
 def gather_inputs(config: dict) -> dict:
     """
     Gather possible inputs from a user directory.

--- a/src/pymorize/gather_inputs.py
+++ b/src/pymorize/gather_inputs.py
@@ -16,7 +16,7 @@ _PATTERN_ENV_VAR_NAME_ADDR = "/pymorize/pattern_env_var_name"
 _PATTERN_ENV_VAR_NAME_DEFAULT = "PYMORIZE_INPUT_PATTERN"
 """str: The default value for the environment variable to be used for the pattern"""
 _PATTERN_ENV_VAR_VALUE_ADDR = "/pymorize/pattern_env_var_value"
-"""str: The address in the YAML file which stores the environment variable's value to be used if the variable is not set"""
+"""str: The address in the YAML file which stores the environment variable's value"""
 _PATTERN_ENV_VAR_VALUE_DEFAULT = ".*"  # Default: match anything
 """str: The default value for the environment variable's value to be used if the variable is not set"""
 

--- a/src/pymorize/pipeline.py
+++ b/src/pymorize/pipeline.py
@@ -233,7 +233,7 @@ class DefaultPipeline(FrozenPipeline):
     """
 
     STEPS = (
-        "pymorize.generic.load_data",
+        "pymorize.gather_inputs.load_mfdataset",
         "pymorize.generic.create_cmor_directories",
         "pymorize.units.handle_unit_conversion",
     )

--- a/tests/configs/test_config.yaml
+++ b/tests/configs/test_config.yaml
@@ -29,5 +29,8 @@ rules:
     cmor_variable: "tas"
     input_type: "xr.DataArray"
     input_source: "xr_tutorial"
-    input_patterns:
-      - "test_input"
+    inputs:
+      - path: "./"
+        pattern: "test_input"
+      - path: "./some/other/path"
+        pattern: "test_input2"

--- a/tests/fixtures/sample_rules.py
+++ b/tests/fixtures/sample_rules.py
@@ -7,9 +7,15 @@ from pymorize.rule import Rule
 @pytest.fixture
 def simple_rule():
     return Rule(
-        input_patterns=[
-            r"/some/files/containing/var1.*.nc",
-            r"/some/other/files/containing/var1_(?P<year>\d{4}).nc",
+        inputs=[
+            {
+                "path": "/some/files/containing/",
+                "pattern": "var1.*.nc",
+            },
+            {
+                "path": "/some/other/files/containing/",
+                "pattern": "var1_(?P<year>\d{4}).nc",
+            },
         ],
         cmor_variable="var1",
         pipelines=["pymorize.pipeline.TestingPipeline"],
@@ -19,9 +25,15 @@ def simple_rule():
 @pytest.fixture
 def rule_with_mass_units():
     r = Rule(
-        input_patterns=[
-            r"/some/files/containing/var1.*.nc",
-            r"/some/other/files/containing/var1_(?P<year>\d{4}).nc",
+        inputs=[
+            {
+                "path": "/some/files/containing/",
+                "pattern": "var1.*.nc",
+            },
+            {
+                "path": "/some/other/files/containing/",
+                "pattern": "var1_(?P<year>\d{4}).nc",
+            },
         ],
         cmor_variable="var1",
         pipelines=["pymorize.pipeline.TestingPipeline"],
@@ -47,9 +59,15 @@ def rule_with_mass_units():
 @pytest.fixture
 def rule_with_units():
     r = Rule(
-        input_patterns=[
-            r"/some/files/containing/var1.*.nc",
-            r"/some/other/files/containing/var1_(?P<year>\d{4}).nc",
+        inputs=[
+            {
+                "path": "/some/files/containing/",
+                "pattern": "var1.*.nc",
+            },
+            {
+                "path": "/some/other/files/containing/",
+                "pattern": "var1_(?P<year>\d{4}).nc",
+            },
         ],
         cmor_variable="var1",
         pipelines=["pymorize.pipeline.TestingPipeline"],

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -6,18 +6,6 @@ from pymorize.pipeline import TestingPipeline
 from pymorize.rule import Rule
 
 
-@pytest.fixture
-def simple_rule():
-    return Rule(
-        input_patterns=[
-            r"/some/files/containing/var1.*.nc",
-            r"/some/other/files/containing/var1_(?P<year>\d{4}).nc",
-        ],
-        cmor_variable="var1",
-        pipelines=["pymorize.pipeline.TestingPipeline"],
-    )
-
-
 def test_direct_init(simple_rule):
     rule = simple_rule
     assert all(isinstance(ip, re.Pattern) for ip in rule.input_patterns)
@@ -27,9 +15,15 @@ def test_direct_init(simple_rule):
 
 def test_from_dict():
     data = {
-        "input_patterns": [
-            r"/some/files/containing/var1.*.nc",
-            r"/some/other/files/containing/var1_(?P<year>\d{4}).nc",
+        "inputs": [
+            {
+                "path": "/some/files/containing/",
+                "pattern": "var1.*.nc",
+            },
+            {
+                "path": "/some/other/files/containing/",
+                "pattern": r"var1_(?P<year>\d{4}).nc",
+            },
         ],
         "cmor_variable": "var1",
         "pipelines": ["pymorize.pipeline.TestingPipeline"],
@@ -42,11 +36,13 @@ def test_from_dict():
 
 def test_from_yaml():
     yaml_str = """
-    input_patterns: 
-      - /some/files/containing/var1.*.nc
-      - /some/other/files/containing/var1_(?P<year>\d{4}).nc
+    inputs:
+        - path: /some/files/containing/
+          pattern: var1.*.nc
+        - path: /some/other/files/containing/
+          pattern: var1_(?P<year>\d{4}).nc
     cmor_variable: var1
-    pipelines: 
+    pipelines:
       - pymorize.pipeline.TestingPipeline
     """
     rule = Rule.from_yaml(yaml_str)


### PR DESCRIPTION
# Summary
- **fix: small mistake in gather inputs**
- **fix(gather_inputs.py): deprecates the gather_inputs function**
- **feat: new API for inputs in Rule**
- **doc: fix too long docstring**

# Description

This changes the way the Rule API works. You now need to give Rule objects a list of dictionaries:

```yaml
rules:
  - name: my_rule
    inputs:
      - path: "/some/location/with/files"
        pattern: ".*nc"
      - path: "/some/location/with/more/files"
        pattern: "EXPID_fesom_thetao_.*nc"
```

The old API, using `input_patterns` now raises deprecation warnings. I have not tested if it still work technically, but it should (maybe).

In any case, this is the way to go for the future.
