### PR TITLE
Script Steps

### DIFF
--- a/src/pymorize/pipeline.py
+++ b/src/pymorize/pipeline.py
@@ -11,7 +11,7 @@ from prefect.tasks import Task
 from prefect_dask import DaskTaskRunner
 
 from .logging import logger
-from .utils import get_callable_by_name
+from .utils import get_callable
 
 
 class Pipeline:
@@ -88,6 +88,10 @@ class Pipeline:
         )
 
     @classmethod
+    def from_callable_strings(cls, step_strings: list, name=None):
+        return cls.from_list([get_callable(name) for name in qualnames], name=name)
+
+    @classmethod
     def from_dict(cls, data):
         if "uses" in data and "steps" in data:
             raise ValueError("Cannot have both 'uses' and 'steps' to create a pipeline")
@@ -95,7 +99,7 @@ class Pipeline:
             # FIXME(PG): This is bad. What if I need to pass arguments to the constructor?
             return get_callable_by_name(data["uses"])(name=data.get("name"))
         if "steps" in data:
-            return cls.from_qualname_list(data["steps"], name=data.get("name"))
+            return cls.from_callable_strings(data["steps"], name=data.get("name"))
         raise ValueError("Pipeline data must have 'uses' or 'steps' key")
 
 

--- a/src/pymorize/pipeline.py
+++ b/src/pymorize/pipeline.py
@@ -2,16 +2,13 @@
 Pipeline of the data processing steps.
 """
 
-import json
-import os
-
 import randomname
 from prefect import flow
 from prefect.tasks import Task
 from prefect_dask import DaskTaskRunner
 
 from .logging import logger
-from .utils import get_callable
+from .utils import get_callable, get_callable_by_name
 
 
 class Pipeline:
@@ -89,7 +86,7 @@ class Pipeline:
 
     @classmethod
     def from_callable_strings(cls, step_strings: list, name=None):
-        return cls.from_list([get_callable(name) for name in qualnames], name=name)
+        return cls.from_list([get_callable(name) for name in step_strings], name=name)
 
     @classmethod
     def from_dict(cls, data):


### PR DESCRIPTION
Allows users to specify custom steps via the `script://` method. This should point 
to a full file path with a function name. Function signature should be the same as
any other step function.


```python
def my_step(data, rule):
    # do something
    return data
```

```yaml
pipelines:
    - name: my_pipeline
      steps:
        - script://path/to/my_step.py:my_step
```
    
