### PR TITLE
Rule Inheritance

### DIFF
--- a/doc/pymorize_building_blocks.rst
+++ b/doc/pymorize_building_blocks.rst
@@ -12,13 +12,15 @@ The configuration is the central piece of the ``pymorize`` CLI. It is a YAML fil
 the CLI. The configuration file is divided into four sections:
 
 1. ``pymorize``: This section contains the configuration for the CLI itself. It specifies the program version, log verbosity, the location of the user configuration file, and the location of the log file.
-2. ``global``: This section contains information that will be passed to all pipelines. You will specify the location of the data directory (your model output files),
+2. ``general``: This section contains information that will be passed to all pipelines. You will specify the location of the data directory (your model output files),
    the output directory (where re-written data should be stored), the location of the CMOR tables, the location of your model's geometry description file (or files), and
    any other information that may be needed by all pipelines.
 3. ``pipelines``: This section contains the configuration for the pipelines. Each pipeline is a sequence of operations that will be applied to the data. You can specify the name of the pipeline, the class
    that implements the pipeline, and any parameters that the pipeline needs.
 4. ``rules``: This section contains the configuration for the rules. Each rule describes a set of files needed to produce a CMOR output variable. You must specify the CMOR variable of interest, the input
    patterns to use to find the files, and the pipeline(s) to apply to the files.
+5. ``inherit``: This section contains key-value pairs that will be added to all rules, unless the rules already have an attribute
+   of this name attached to them.
 
 Pipelines
 ---------
@@ -69,4 +71,27 @@ Rules are the heart of the ``pymorize`` CLI. They specify the files needed to pr
   .. note::
 
        If you do not specify a pipeline, the default pipeline will be run!
+
+Inheritance
+-----------
+
+Rules can inherit global values. To do so, you should include them in the ``inherit`` section of the configuration file. Here is an example:
+
+  .. code-block:: yaml
+  
+      # ... other configuration
+      inherit:
+        frequency: mon
+      # ... other configuration
+
+      rules:
+        - name: my_rule
+          cmor_variable: tas
+          patterns:
+            - 'tas_*.nc'
+          pipelines:
+            - my_pipeline
+
+  The rule ``my_rule`` will inherit the frequency ``mon`` from the global configuration, and can be accessed in
+  Python code as ``rule_spec.frequency``.
 

--- a/doc/pymorize_building_blocks.rst
+++ b/doc/pymorize_building_blocks.rst
@@ -92,6 +92,6 @@ Rules can inherit global values. To do so, you should include them in the ``inhe
           pipelines:
             - my_pipeline
 
-  The rule ``my_rule`` will inherit the frequency ``mon`` from the global configuration, and can be accessed in
-  Python code as ``rule_spec.frequency``.
+The rule ``my_rule`` will inherit the frequency ``mon`` from the global configuration, and can be accessed in
+Python code as ``rule_spec.frequency``.
 

--- a/src/pymorize/cmorizer.py
+++ b/src/pymorize/cmorizer.py
@@ -28,11 +28,13 @@ class CMORizer:
         pipelines_cfg=None,
         rules_cfg=None,
         dask_cfg=None,
+        inherit_cfg=None,
         **kwargs,
     ):
         self._general_cfg = general_cfg or {}
         self._pymorize_cfg = pymorize_cfg or {}
         self._dask_cfg = dask_cfg or {}
+        self._inherit_cfg = inherit_cfg or {}
         self.rules = rules_cfg or []
         self.pipelines = pipelines_cfg or []
 
@@ -203,6 +205,12 @@ class CMORizer:
 
     def _post_init_create_rules(self):
         self.rules = [Rule.from_dict(p) for p in self.rules if not isinstance(p, Rule)]
+        self._post_init_inherit_rules()
+
+    def _post_init_inherit_rules(self):
+        for rule_attr, rule_value in self._inherit_cfg.items():
+            for rule in self.rules:
+                rule.set(rule_attr, rule_value)
 
     def _post_init_checks(self):
         # Sanity Checks:
@@ -225,6 +233,7 @@ class CMORizer:
         for rule in data.get("rules", []):
             rule_obj = Rule.from_dict(rule)
             instance.add_rule(rule_obj)
+        instance._post_init_inherit_rules()
         if "pipelines" in data:
             if not PIPELINES_VALIDATOR.validate({"pipelines": data["pipelines"]}):
                 raise ValueError(PIPELINES_VALIDATOR.errors)

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -57,7 +57,7 @@ class Rule:
     def get(self, key, default=None):
         return getattr(self, key, default)
 
-    def set(self, key, value, force=False):
+    def set(self, key, value, force=False, warn=True):
         """
         Set a new attribute for the object.
 
@@ -70,6 +70,10 @@ class Rule:
         force : bool, optional
             If True, the attribute will be overwritten if it already exists.
             If False (default), an AttributeError will be raised if the attribute already exists.
+        warn : bool, optional
+            If True (default) a warning will be issued if the attribute already exists, and
+            it will not be overwritten. If False, an AttributeError will be raised if the attribute
+            already exists.
 
         Returns
         -------
@@ -79,12 +83,17 @@ class Rule:
         Raises
         ------
         AttributeError
-            If the attribute already exists and force is False.
+            If the attribute already exists and force and warn are both False.
         """
         if hasattr(self, key) and not force:
-            raise AttributeError(
-                f"Attribute {key} already exists. Use force=True to overwrite."
-            )
+            if warn:
+                warnings.warn(
+                    f"Attribute {key} already exists. Use force=True to overwrite."
+                )
+            else:
+                raise AttributeError(
+                    f"Attribute {key} already exists. Use force=True to overwrite."
+                )
         return setattr(self, key, value)
 
     def __repr__(self):

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -57,6 +57,36 @@ class Rule:
     def get(self, key, default=None):
         return getattr(self, key, default)
 
+    def set(self, key, value, force=False):
+        """
+        Set a new attribute for the object.
+
+        Parameters
+        ----------
+        key : str
+            The name of the attribute to set.
+        value : Any
+            The value to set for the attribute.
+        force : bool, optional
+            If True, the attribute will be overwritten if it already exists.
+            If False (default), an AttributeError will be raised if the attribute already exists.
+
+        Returns
+        -------
+        value : Any
+            Returns the value appended to the object. This is the same behaviour as setattr.
+
+        Raises
+        ------
+        AttributeError
+            If the attribute already exists and force is False.
+        """
+        if hasattr(self, key) and not force:
+            raise AttributeError(
+                f"Attribute {key} already exists. Use force=True to overwrite."
+            )
+        return setattr(self, key, value)
+
     def __repr__(self):
         return f"Rule(inputs={self.inputs}, cmor_variable={self.cmor_variable}, pipelines={self.pipelines}, tables={self.tables}, data_request_variables={self.data_request_variables})"
 


### PR DESCRIPTION
This allows for inheritance of global attributes to Rule objects.

For example:

```yaml
  # ... other configuration
  inherit:
    frequency: mon
  # ... other configuration

  rules:
    - name: my_rule
      cmor_variable: tas
      patterns:
        - 'tas_*.nc'
      pipelines:
        - my_pipeline
```

This would give a `Rule` object like so:
```python
>>> rule = Rule(...)
>>> rule.frequency
'mon'
```

It also ensures that an attribute specifically set on the rule will
be used instead of the global setting (local version wins):

```yaml
  # ... other configuration
  inherit:
    frequency: mon
    my_attr: foo
  # ... other configuration

  rules:
    - name: my_rule
      cmor_variable: tas
      my_attr: not_foo
      patterns:
        - 'tas_*.nc'
      pipelines:
        - my_pipeline
```
Gives:
```python
>>> rule = Rule(...)
>>> rule.my_attr
'not_foo'
```
