### PR TITLE
API: Rule

### DIFF
--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -231,8 +231,8 @@ class Rule:
         """Remove a data request variable from the rule."""
         self.data_request_variables.remove(drv)
 
-    @deprecation.deprecated(details="Use inputs instead")
     def input_patterns(self):
+        """Return a list of compiled regex patterns for the input files."""
         return [re.compile(f"{inp.path}/{inp.pattern}") for inp in self.inputs]
 
     def clone(self):

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -231,6 +231,7 @@ class Rule:
         """Remove a data request variable from the rule."""
         self.data_request_variables.remove(drv)
 
+    @property
     def input_patterns(self):
         """Return a list of compiled regex patterns for the input files."""
         return [re.compile(f"{inp.path}/{inp.pattern}") for inp in self.inputs]

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -8,7 +8,7 @@ from pymorize.rule import Rule
 
 def test_direct_init(simple_rule):
     rule = simple_rule
-    assert all(isinstance(ip, re.Pattern) for ip in rule.inputs)
+    assert all(isinstance(ip, re.Pattern) for ip in rule.input_patterns)
     assert isinstance(rule.cmor_variable, str)
     assert all(isinstance(p, str) for p in rule.pipelines)
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -8,7 +8,7 @@ from pymorize.rule import Rule
 
 def test_direct_init(simple_rule):
     rule = simple_rule
-    assert all(isinstance(ip, re.Pattern) for ip in rule.input_patterns)
+    assert all(isinstance(ip, re.Pattern) for ip in rule.inputs)
     assert isinstance(rule.cmor_variable, str)
     assert all(isinstance(p, str) for p in rule.pipelines)
 


### PR DESCRIPTION
This is the first in a series of pull requests to clean up the API of the main pymorize objects. Here, `Rule` objects are better documented.
- - - -
## Copilot Summary
This pull request includes several changes to the `Rule` class in `src/pymorize/rule.py`, focusing on encapsulation, documentation, and deprecation warnings. The most important changes include renaming the `pipelines` attribute to `_pipelines` and adding getter methods, enhancing method documentation, and adding deprecation warnings for certain methods.

Encapsulation and attribute access:

* Renamed the `pipelines` attribute to `_pipelines` and added a `pipelines` property for controlled access. (`src/pymorize/rule.py`, [[1]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L46-R46) [[2]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778R57-R84) [[3]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L131-R158) [[4]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L142-R186)

Documentation improvements:

* Added detailed docstrings to several methods, including `get`, `set`, `from_dict`, `from_yaml`, `add_table`, `remove_table`, `add_input`, `add_data_request_variable`, `remove_data_request_variable`, `input_patterns`, `clone`, and `expand_drvs`. (`src/pymorize/rule.py`, [[1]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778R57-R84) [[2]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L142-R186) [[3]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778R196-R199) [[4]](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778R210-R256)

Deprecation warnings:

* Added a deprecation warning to the `to_yaml` method, indicating it should be avoided. (`src/pymorize/rule.py`, [src/pymorize/rule.pyR196-R199](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778R196-R199))


Dependency updates:

* Imported the `deprecation` module to handle deprecation warnings. (`src/pymorize/rule.py`, [src/pymorize/rule.pyL5-R6](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L5-R6))