### PR TITLE
Improve user interface for the dask dashboard

### DIFF
--- a/src/pymorize/cluster.py
+++ b/src/pymorize/cluster.py
@@ -1,0 +1,34 @@
+"""
+This module contains the functions to manage the Dask cluster.
+"""
+import dask
+
+from .logging import logger
+
+def set_dashboard_link(cluster):
+    """
+    Checks whether the default user configuration for the dashboard link is valid.
+    If the configuration is invalid it tried to catch the following errors:
+
+    * KeyError: 'JUPYTERHUB_SERVICE_PREFIX' -> The dashboard link is not valid because
+      the cluster was not launched from JupyterHub. In this case, the default dashboard
+      link is set to 'http://{host}:8787'.
+
+    Parameters
+    ----------
+    cluster : dask_jobqueue.SLURMCluster
+        The Dask cluster to set the dashboard link.
+    """
+    try:
+        _ = cluster.dashboard_link
+    except KeyError as e:
+        if "JUPYTERHUB_SERVICE_PREFIX" in str(e):
+            logger.debug(
+                "Trying to use JupyterHub prefix for the dashboard link, but the it "
+                "was not launched from JupyterHub. Falling back to the default "
+                "dashboard link."
+            )
+            default_dashboard_link = "http://{host}:8787"
+            dask.config.set({"distributed.dashboard.link": default_dashboard_link})
+        else:
+            raise e

--- a/src/pymorize/cmorizer.py
+++ b/src/pymorize/cmorizer.py
@@ -14,9 +14,14 @@ from prefect import flow, task
 from prefect.futures import wait
 from rich.progress import track
 
+from .cluster import set_dashboard_link
 from .config import PymorizeConfig, PymorizeConfigManager, parse_bool
-from .data_request import (DataRequest, DataRequestTable, DataRequestVariable,
-                           IgnoreTableFiles)
+from .data_request import (
+    DataRequest,
+    DataRequestTable,
+    DataRequestVariable,
+    IgnoreTableFiles,
+)
 from .filecache import fc
 from .logging import logger
 from .pipeline import Pipeline
@@ -120,6 +125,7 @@ class CMORizer:
         # FIXME: In the future, we can support PBS, too.
         logger.info("Setting up SLURMCluster...")
         self._cluster = SLURMCluster()
+        set_dashboard_link(self._cluster)
         cluster_mode = self._pymorize_cfg.get("cluster_mode", "adapt")
         if cluster_mode == "adapt":
             min_jobs = self._pymorize_cfg.get("minimum_jobs", 1)


### PR DESCRIPTION
# Thank you for contributing! 🎉

## Summary of the most important changes
This pull request introduces:
- [x] a new module for managing the Dask cluster and integrates it with the existing codebase and adds a function to set the dashboard link for the Dask cluster and updating the `cmorizer` module to use this new function.
- [ ] Reports the `pymorize ssh-tunnel` command that you need to run in your laptop

### New module for Dask cluster management:

* [`src/pymorize/cluster.py`](diffhunk://#diff-cfb787f8052ef47c572d821afdc2c745eeb29027b9cbb0e3ef85a830695e8010R1-R34): Added a new module containing the `set_dashboard_link` function to manage the Dask cluster's dashboard link, including handling errors when the cluster is not launched from JupyterHub.

### Integration with existing codebase:

* [`src/pymorize/cmorizer.py`](diffhunk://#diff-9deea47805fe528815a5e35850622c720823cb8c6abd547246359d9502aae47aR17-R24): Imported the `set_dashboard_link` function from the new `cluster` module and used it in the `_post_init_create_dask_cluster` method to set the dashboard link for the SLURMCluster. [[1]](diffhunk://#diff-9deea47805fe528815a5e35850622c720823cb8c6abd547246359d9502aae47aR17-R24) [[2]](diffhunk://#diff-9deea47805fe528815a5e35850622c720823cb8c6abd547246359d9502aae47aR128) in this PR.

## Checklist
+ [ ] I have tested the changes in this PR.
+ [ ] I have updated the documentation.
+ [ ] If I have made a new step which requires new arguments, these are added to the `validate.py` file 
      so that the user can see documentation for the arguments.

