### PR TITLE
feat: moves depluralization onto the rule

### DIFF
--- a/src/pymorize/cmorizer.py
+++ b/src/pymorize/cmorizer.py
@@ -327,9 +327,7 @@ class CMORizer:
     def _rules_depluralize_drvs(self):
         """Ensures that only one data request variable is assigned to each rule"""
         for rule in self.rules:
-            assert len(rule.data_request_variables) == 1
-            rule.data_request_variable = rule.data_request_variables[0]
-            del rule.data_request_variables
+            rule.depluralize_drvs()
 
     def _post_init_create_pipelines(self):
         pipelines = []

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -282,6 +282,12 @@ class Rule:
             clones.append(rule_clone)
         return clones
 
+    def depluralize_drvs(self):
+        """Depluralizes Data Request Variables to just a single entry"""
+        assert len(self.data_request_variables) == 1
+        self.data_request_variable = self.data_request_variables[0]
+        del self.data_request_variables
+
     # FIXME: Not used and broken+
     # @classmethod
     # def from_interface(cls, cmor_table=None):


### PR DESCRIPTION
This pull request refactors the way data request variables are depluralized in the `pymorize` module by moving the logic to a new method in the `rule.py` file. The changes improve code modularity and readability by separating concerns.

Refactoring of depluralization logic:

* [`src/pymorize/cmorizer.py`](diffhunk://#diff-9deea47805fe528815a5e35850622c720823cb8c6abd547246359d9502aae47aL330-R330): Replaced the inline depluralization logic in `_rules_depluralize_drvs` with a call to the new `depluralize_drvs` method.
* [`src/pymorize/rule.py`](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778R285-R290): Added a new method `depluralize_drvs` to handle the depluralization of data request variables, ensuring that the logic is encapsulated within the `rule` class.