### PR TITLE
feat: adds caching subcommand to main cli

### DIFF
--- a/src/pymorize/cli.py
+++ b/src/pymorize/cli.py
@@ -102,6 +102,19 @@ def process(config_file):
 
 @cli.command()
 @click_loguru.init_logger()
+@click.argument("config_file", type=click.Path(exists=True))
+def prefect_check(config_file):
+    add_report_logger()
+    logger.info(f"Checking prefect with dummy flow using {config_file}")
+    with open(config_file, "r") as f:
+        cfg = yaml.safe_load(f)
+        cmorizer = CMORizer.from_dict(cfg)
+        client = Client(cmorizer._cluster)  # noqa: F841
+        cmorizer.check_prefect()
+
+
+@cli.command()
+@click_loguru.init_logger()
 def table_explorer():
     logger.info("Launching table explorer...")
     with resources.path("pymorize", "webapp.py") as webapp_path:
@@ -267,9 +280,26 @@ def populate_cache(files: List, verbose, quiet, logfile, profile_mem):
 ################################################################################
 ################################################################################
 ################################################################################
-cli.add_command(validate)
-cli.add_command(develop)
+
+################################################################################
+# Imported subcommands
+################################################################################
+
 cli.add_command(ssh_tunnel_cli, name="ssh-tunnel")
+
+################################################################################
+
+################################################################################
+# Defined subcommands
+################################################################################
+
+cli.add_command(develop)
+cli.add_command(validate)
+cli.add_command(cache)
+
+################################################################################
+################################################################################
+################################################################################
 
 
 def main():


### PR DESCRIPTION
This pull request includes updates to the `src/pymorize/cli.py` file to add a new command and reorganize existing commands for better structure and clarity. The most important changes include the addition of a new `prefect_check` command and the reorganization of command registrations.

### New Command Addition:

* Added a new `prefect_check` command that initializes a logger, reads a configuration file, and checks a prefect flow using the provided configuration. (`[src/pymorize/cli.pyR103-R115](diffhunk://#diff-52f600cc9a0f575806575a10c0aaaf0af77b906d98f506ebc5e7f3e5a35f4130R103-R115)`)

### Command Reorganization:

* Reorganized the command registrations by separating imported subcommands and defined subcommands into distinct sections for better readability. (`[src/pymorize/cli.pyL270-R303](diffhunk://#diff-52f600cc9a0f575806575a10c0aaaf0af77b906d98f506ebc5e7f3e5a35f4130L270-R303)`)