### PR TITLE
Cleanup/rule

### DIFF
--- a/src/pymorize/cli.py
+++ b/src/pymorize/cli.py
@@ -102,6 +102,19 @@ def process(config_file):
 
 @cli.command()
 @click_loguru.init_logger()
+@click.argument("config_file", type=click.Path(exists=True))
+def prefect_check(config_file):
+    add_report_logger()
+    logger.info(f"Checking prefect with dummy flow using {config_file}")
+    with open(config_file, "r") as f:
+        cfg = yaml.safe_load(f)
+        cmorizer = CMORizer.from_dict(cfg)
+        client = Client(cmorizer._cluster)  # noqa: F841
+        cmorizer.check_prefect()
+
+
+@cli.command()
+@click_loguru.init_logger()
 def table_explorer():
     logger.info("Launching table explorer...")
     with resources.path("pymorize", "webapp.py") as webapp_path:
@@ -267,9 +280,26 @@ def populate_cache(files: List, verbose, quiet, logfile, profile_mem):
 ################################################################################
 ################################################################################
 ################################################################################
-cli.add_command(validate)
-cli.add_command(develop)
+
+################################################################################
+# Imported subcommands
+################################################################################
+
 cli.add_command(ssh_tunnel_cli, name="ssh-tunnel")
+
+################################################################################
+
+################################################################################
+# Defined subcommands
+################################################################################
+
+cli.add_command(develop)
+cli.add_command(validate)
+cli.add_command(cache)
+
+################################################################################
+################################################################################
+################################################################################
 
 
 def main():

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -264,33 +264,3 @@ class Rule:
             rule_clone.data_request_variables = [drv_clone]
             clones.append(rule_clone)
         return clones
-
-    # FIXME: Not used and broken+
-    # @classmethod
-    # def from_interface(cls, cmor_table=None):
-    #     """
-    #     Generates a Rule via a wizard-like interface
-
-    #     Parameters
-    #     ----------
-    #     cmor_table : dict, optional
-    #         A dictionary with the CMOR table. If provided, the user will be
-    #         prompted to select a CMOR variable from the table. Must contain a key
-    #         "variable_entry" with an iterable of CMOR variable names.
-    #     """
-    #     if cmor_table is None:
-    #         cmor_variable = questionary.text("CMOR variable: ").ask()
-    #     else:
-    #         cmor_variable = questionary.autocomplete(
-    #             "CMOR variable: ", cmor_table["variable_entry"]
-    #         ).ask()
-    #     input_patterns = []
-    #     while True:
-    #         input_patterns.append(questionary.text("Input pattern as regex: ").ask())
-    #         if input_patterns:
-    #             [logger.info(p) for p in input_patterns]
-    #         if not questionary.confirm(
-    #             f"Add another input pattern for {cmor_variable}?"
-    #         ).ask():
-    #             break
-    #     return cls(input_patterns=input_patterns, cmor_variable=cmor_variable)

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -135,13 +135,6 @@ class Rule:
                 )
         return setattr(self, key, value)
 
-    def __repr__(self):
-        return (
-            f"Rule(inputs={self.inputs}, cmor_variable={self.cmor_variable}, "
-            f"pipelines={self.pipelines}, tables={self.tables}, "
-            f"data_request_variables={self.data_request_variables})"
-        )
-
     def __str__(self):
         return f"Rule for {self.cmor_variable} with input patterns {self.input_patterns} and pipelines {self.pipelines}"
 
@@ -212,16 +205,6 @@ class Rule:
     def from_yaml(cls, yaml_str):
         """Wrapper around ``from_dict`` for initializing from YAML"""
         return cls.from_dict(yaml.safe_load(yaml_str))
-
-    # @deprecation.deprecated(details="This shouldn't be used, avoid it")
-    # def to_yaml(self):
-    #     return yaml.dump(
-    #         {
-    #             "inputs": [p.to_dict() for p in self.input_patterns],
-    #             "cmor_variable": self.cmor_variable,
-    #             "pipelines": [p.to_dict() for p in self.pipelines],
-    #         }
-    #     )
 
     def add_table(self, tbl):
         """Add a table to the rule"""


### PR DESCRIPTION
### Needed before
+ [ ] #94 

### Copilot Summary
This pull request includes several changes to the `src/pymorize` project, focusing on adding new commands to the CLI, cleaning up unused code, and organizing subcommands. The most important changes include the addition of a new CLI command for checking Prefect, reorganization of CLI subcommands, and removal of deprecated and unused methods in the `rule.py` file.

### Additions to CLI:

* Added a new CLI command `prefect_check` to check Prefect with a dummy flow using a given configuration file. (`src/pymorize/cli.py`, [src/pymorize/cli.pyR103-R115](diffhunk://#diff-52f600cc9a0f575806575a10c0aaaf0af77b906d98f506ebc5e7f3e5a35f4130R103-R115))

### Reorganization of CLI subcommands:

* Reorganized the addition of CLI subcommands, grouping imported and defined subcommands separately. (`src/pymorize/cli.py`, [src/pymorize/cli.pyL270-R303](diffhunk://#diff-52f600cc9a0f575806575a10c0aaaf0af77b906d98f506ebc5e7f3e5a35f4130L270-R303))

### Code cleanup in `rule.py`:

* Removed the `__repr__` method from the `Rule` class. (`src/pymorize/rule.py`, [src/pymorize/rule.pyL138-L144](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L138-L144))
* Removed deprecated and unused `to_yaml` method. (`src/pymorize/rule.py`, [src/pymorize/rule.pyL216-L225](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L216-L225))
* Removed an unused and broken `from_interface` method. (`src/pymorize/rule.py`, [src/pymorize/rule.pyL284-L313](diffhunk://#diff-2c62d44942e58feeeb6acdb6b358409aabb2901bf54c747b053a42fcebc3d778L284-L313))