### PR TITLE
FIX: Unlimited time dimension

### DIFF
--- a/src/pymorize/config.py
+++ b/src/pymorize/config.py
@@ -201,6 +201,22 @@ class PymorizeConfig:
                 ],
             ),
         )
+        xarray_time_dtype = Option(
+            default="float64",
+            doc="The dtype to use for time axis in xarray.",
+            parser=ChoiceOf(
+                str,
+                choices=[
+                    "float64",
+                    "datetime64[ns]",
+                ],
+            ),
+        )
+        xarray_time_unlimited = Option(
+            default="yes",
+            doc="Whether the time axis is unlimited in xarray.",
+            parser=_parse_bool,
+        )
 
 
 class PymorizeConfigManager(ConfigManager):

--- a/src/pymorize/config.py
+++ b/src/pymorize/config.py
@@ -237,6 +237,11 @@ class PymorizeConfig:
             default="T",
             doc="Which axis to set for the time axis in xarray.",
         )
+        xarray_time_remove_fill_value_attr = Option(
+            parser=_parse_bool,
+            default="yes",
+            doc="Whether to remove the fill_value attribute from the time axis in xarray.",
+        )
 
 
 class PymorizeConfigManager(ConfigManager):

--- a/src/pymorize/config.py
+++ b/src/pymorize/config.py
@@ -217,6 +217,26 @@ class PymorizeConfig:
             doc="Whether the time axis is unlimited in xarray.",
             parser=_parse_bool,
         )
+        xarray_time_set_standard_name = Option(
+            default="yes",
+            doc="Whether to set the standard name for the time axis in xarray.",
+            parser=_parse_bool,
+        )
+        xarray_time_set_long_name = Option(
+            default="yes",
+            doc="Whether to set the long name for the time axis in xarray.",
+            parser=_parse_bool,
+        )
+        xarray_time_enable_set_axis = Option(
+            parser=_parse_bool,
+            default="yes",
+            doc="Whether to enable setting the axis for the time axis in xarray.",
+        )
+        xarray_time_taxis_str = Option(
+            parser=str,
+            default="T",
+            doc="Which axis to set for the time axis in xarray.",
+        )
 
 
 class PymorizeConfigManager(ConfigManager):

--- a/src/pymorize/files.py
+++ b/src/pymorize/files.py
@@ -197,6 +197,16 @@ def save_dataset(da: xr.DataArray, rule):
         )
     if isinstance(da, xr.DataArray):
         da = da.to_dataset()
+    # Not sure about this, maybe it needs to go above, before the is_scalar
+    # check
+    if rule._pymorize_cfg("xarray_time_set_standard_name"):
+        da[time_label].attrs["standard_name"] = "time"
+    if rule._pymorize_cfg("xarray_time_set_long_name"):
+        da[time_label].attrs["long_name"] = "time"
+    if rule._pymorize_cfg("xarray_time_enable_set_axis"):
+        time_axis_str = rule._pymorize_cfg("xarray_time_taxis_str")
+        da[time_label].attrs["axis"] = time_axis_str
+
     file_timespan = getattr(rule, "file_timespan", None)
     if not needs_resampling(da, file_timespan):
         filepath = create_filepath(da, rule)

--- a/src/pymorize/files.py
+++ b/src/pymorize/files.py
@@ -206,7 +206,7 @@ def save_dataset(da: xr.DataArray, rule):
     if rule._pymorize_cfg("xarray_time_enable_set_axis"):
         time_axis_str = rule._pymorize_cfg("xarray_time_taxis_str")
         da[time_label].attrs["axis"] = time_axis_str
-    if rule._pymorize_cfg("xarray_time_remove_fill_vallue_attr"):
+    if rule._pymorize_cfg("xarray_time_remove_fill_value_attr"):
         time_encoding["_FillValue"] = None
 
     file_timespan = getattr(rule, "file_timespan", None)

--- a/src/pymorize/files.py
+++ b/src/pymorize/files.py
@@ -206,6 +206,8 @@ def save_dataset(da: xr.DataArray, rule):
     if rule._pymorize_cfg("xarray_time_enable_set_axis"):
         time_axis_str = rule._pymorize_cfg("xarray_time_taxis_str")
         da[time_label].attrs["axis"] = time_axis_str
+    if rule._pymorize_cfg("xarray_time_remove_fill_vallue_attr"):
+        time_encoding["_FillValue"] = None
 
     file_timespan = getattr(rule, "file_timespan", None)
     if not needs_resampling(da, file_timespan):

--- a/src/pymorize/files.py
+++ b/src/pymorize/files.py
@@ -173,7 +173,17 @@ def save_dataset(da: xr.DataArray, rule):
     """
     time_dtype = rule._pymorize_cfg("xarray_time_dtype")
     time_unlimited = rule._pymorize_cfg("xarray_time_unlimited")
-    time_encoding = {"dtype": time_dtype, "unlimited": time_unlimited}
+    # FIXME(PG): This probably should be a separate function to make it cleaner...
+    if time_unlimited:
+        if not hasattr(da, "encoding"):
+            da.encoding = {}
+
+        if "unlimited_dims" not in da.encoding:
+            da.encoding["unlimited_dims"] = ["time"]
+        else:
+            if "time" not in da.encoding["unlimited_dims"]:
+                da.encoding["unlimited_dims"].append("time")
+    time_encoding = {"dtype": time_dtype}
     time_encoding = {k: v for k, v in time_encoding.items() if v is not None}
     if not has_time_axis(da):
         filepath = create_filepath(da, rule)

--- a/src/pymorize/files.py
+++ b/src/pymorize/files.py
@@ -173,16 +173,9 @@ def save_dataset(da: xr.DataArray, rule):
     """
     time_dtype = rule._pymorize_cfg("xarray_time_dtype")
     time_unlimited = rule._pymorize_cfg("xarray_time_unlimited")
-    # FIXME(PG): This probably should be a separate function to make it cleaner...
+    extra_kwargs = {}
     if time_unlimited:
-        if not hasattr(da, "encoding"):
-            da.encoding = {}
-
-        if "unlimited_dims" not in da.encoding:
-            da.encoding["unlimited_dims"] = ["time"]
-        else:
-            if "time" not in da.encoding["unlimited_dims"]:
-                da.encoding["unlimited_dims"].append("time")
+        extra_kwargs.update({"unlimited_dims": ["time"]})
     time_encoding = {"dtype": time_dtype}
     time_encoding = {k: v for k, v in time_encoding.items() if v is not None}
     if not has_time_axis(da):
@@ -200,6 +193,7 @@ def save_dataset(da: xr.DataArray, rule):
             mode="w",
             format="NETCDF4",
             encoding={"time": time_encoding},
+            **extra_kwargs,
         )
     if isinstance(da, xr.DataArray):
         da = da.to_dataset()
@@ -211,6 +205,7 @@ def save_dataset(da: xr.DataArray, rule):
             mode="w",
             format="NETCDF4",
             encoding={"time": time_encoding},
+            **extra_kwargs,
         )
     groups = da.resample(time=file_timespan)
     paths = []
@@ -222,4 +217,5 @@ def save_dataset(da: xr.DataArray, rule):
         datasets,
         paths,
         encoding={"time": time_encoding},
+        **extra_kwargs,
     )

--- a/tests/unit/test_savedataset.py
+++ b/tests/unit/test_savedataset.py
@@ -65,6 +65,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from pymorize.config import PymorizeConfigManager
 from pymorize.files import _filename_time_range, save_dataset
 from pymorize.timeaverage import _get_time_method  # noqa: F401
 
@@ -188,6 +189,7 @@ def test_save_dataset_saves_to_single_file(tmp_path):
     dates = xr.cftime_range(start="2001", periods=24, freq="MS", calendar="noleap")
     da = xr.DataArray(np.arange(24), coords=[dates], dims=["time"], name="foo")
     rule = Mock()
+    rule._pymorize_cfg = PymorizeConfigManager.from_pymorize_cfg({})
     rule.data_request_variable.frequency = "mon"
     rule.data_request_variable.table.table_id = "Omon"
     rule.cmor_variable = "CO2"
@@ -206,6 +208,7 @@ def test_save_dataset_saves_to_multiple_files(tmp_path):
     dates = xr.cftime_range(start="2001", periods=24, freq="MS", calendar="noleap")
     da = xr.DataArray(np.arange(24), coords=[dates], dims=["time"], name="foo")
     rule = Mock()
+    rule._pymorize_cfg = PymorizeConfigManager.from_pymorize_cfg({})
     rule.data_request_variable.frequency = "mon"
     rule.data_request_variable.table.table_id = "Omon"
     rule.cmor_variable = "CO2"


### PR DESCRIPTION
The `time` dimension in a NetCDF file should be marked as `"unlimited"`. This PR enables that, and it can be configured by the end-user.

Default is to set time dimensions to unlimited and store time as a `float64`.
