### PR TITLE
FIX: Inherit can be specified in CMORizer

### DIFF
--- a/src/pymorize/cmorizer.py
+++ b/src/pymorize/cmorizer.py
@@ -485,6 +485,7 @@ class CMORizer:
                 "distributed": data.get("distributed", {}),
                 "jobqueue": data.get("jobqueue", {}),
             },
+            inherit_cfg=data.get("inherit", {}),
         )
         if "rules" in data:
             if not RULES_VALIDATOR.validate({"rules": data["rules"]}):


### PR DESCRIPTION
`CMORizer.from_dict` was ignoring `inherit` when created from a yaml file.
