### PR TITLE
getting subdir_path moved from controlled_vacabularies to global_attr…

### DIFF
--- a/src/pymorize/files.py
+++ b/src/pymorize/files.py
@@ -133,9 +133,7 @@ def create_filepath(ds, rule):
     # check if output sub-directory is needed
     enable_output_subdirs = rule._pymorize_cfg.get("enable_output_subdirs", False)
     if enable_output_subdirs:
-        subdirs = rule.controlled_vocabularies.subdir_path(
-            rule.global_attributes_set_on_rule()
-        )
+        subdirs = rule.ga.subdir_path()
         out_dir = f"{out_dir}/{subdirs}"
     filepath = f"{out_dir}/{name}_{table_id}_{institution}-{source_id}_{experiment_id}_{label}_{grid}_{time_range}.nc"
     Path(filepath).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Past refactoring moved the function `subdir_path` from `controlled_vocabularies` instance to `global_attributes` instance