### PR TITLE
Dynamic checking of requirement steps in pipelines

### DIFF
--- a/src/pymorize/cmorizer.py
+++ b/src/pymorize/cmorizer.py
@@ -321,6 +321,10 @@ class CMORizer:
         for rule in self.rules:
             rule.match_pipelines(self.pipelines, force=force)
 
+    def _crosscheck_pipeines_in_rules(self):
+        for rule in self.rules:
+            rule.crosscheck_pipelines()
+
     def find_matching_rule(
         self, data_request_variable: DataRequestVariable
     ) -> Rule or None:
@@ -606,6 +610,7 @@ class CMORizer:
     def process(self, parallel=None):
         logger.debug("Process start!")
         self._match_pipelines_in_rules()
+        self._crosscheck_pipeines_in_rules()
         if parallel is None:
             parallel = self._pymorize_cfg.get("parallel", True)
         if parallel:

--- a/src/pymorize/rule.py
+++ b/src/pymorize/rule.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import inspect
 import pathlib
 import re
 import typing
@@ -12,6 +13,51 @@ from .data_request.table import DataRequestTable
 from .data_request.variable import DataRequestVariable
 from .gather_inputs import InputFileCollection
 from .logging import logger
+from .pipeline import Pipeline
+
+
+class RuleRequirement:
+    """Defines a requirement which steps must have tagged in order to be valid"""
+
+    def __init__(self, requirement_name: str, requirement_value: typing.Any):
+        """
+        Initialize a RuleRequirement object.
+
+        Parameters
+        ----------
+        requirement_name : str
+            The name of the requirement that the step must satisfy.
+        requirement_value : Any
+            The value of the requirement that the step must satisfy.
+        """
+        self.requirement_name = requirement_name
+        self.requirement_value = requirement_value
+
+    @classmethod
+    def from_dict(cls, d):
+        """Build a RuleRequirement object from a dictionary"""
+        return cls(**d)
+
+    def pipeline_fulfills_requirements(self, pipeline: Pipeline) -> bool:
+        """Check if a pipeline fulfills the requirements of the rule
+
+        Parameters
+        ----------
+        pipeline : Pipeline
+            The pipeline to check
+
+        Returns
+        -------
+        bool
+            True if the pipeline fulfills the requirements, False otherwise
+        """
+        for step in pipeline.steps:
+            step_src = inspect.getsource(step)
+            for line in step_src.split("\n"):
+                if f"_satisfies_{self.requirement_name}" in line:
+                    if str(self.requirement_value) in line:
+                        return True
+        return False
 
 
 class Rule:
@@ -166,6 +212,24 @@ class Rule:
                 raise TypeError(f"{pl} must be a string or a pipeline.Pipeline object!")
         self.pipelines = matched_pipelines
         self._pipelines_are_mapped = True
+
+    def crosscheck_pipelines(self):
+        """
+        Check that all pipelines are valid for the rule.
+
+        This method will raise a ValueError if any of the pipelines in the rule are not valid.
+        """
+        # FIXME: Dynamically get requirements based on CMOR variable. Something like this:
+        # Should be a list of dictionaries containing requirement specifications:
+        # requirements = [{"requirement_name": "cell_methods", "requirement_value": "time: mean"}, ]
+        requirements = [dict(), dict()]
+        for requirement in requirements:
+            rr = RuleRequirement.from_dict(**requirement)
+            req_satisfied = any(
+                rr.pipeline_fulfills_requirements(pl) for pl in self.pipelines
+            )
+            if not req_satisfied:
+                raise ValueError(f"Rule {self.name} does not satisfy requirement {rr}")
 
     @classmethod
     def from_dict(cls, data):


### PR DESCRIPTION
Checks if the pipelines attached to a rule fulfill in any way some tagged requirements.

Requirements look like this in the steps:


```python
def my_awesome_step(data, rule):
    _satisfies_cell_methods = "mean: time"
    data = data.mean(dim="time")
    return data
```

A `step` could satisfy multiple requirements. These should be internal variables, and *might* be used, but I think that they
probably should just be used for checking. 

A `RuleRequirement` helper class is available in `rule.py`, which is used to pased the requirements. Then, each step of each pipeline is
checked for such tags:

```python
my_requirements = {"requirement_name": "cell_methods", "requirement_value": "mean: time"}
rule_requirement = RuleRequirement(**my_requirements)
my_pipeline = Pipeline([my_awesome_step])
rule_requirements.pipeline_fulfills_requirements(my_pipeline)
```

I think that the checking method could use a better name, suggestions are welcome.

This idea is still untested, just a starting point for discussion....
