### PR TITLE
Examples wrong units

### DIFF
--- a/doc/cookbook.rst
+++ b/doc/cookbook.rst
@@ -7,4 +7,5 @@ A showcase of some more complicated use cases.
 If you'd like to contribute with your own recipe, or ask for a recipe, please open a
 documentation issue on `our GitHub repository <https://github.com/esm-tools/pymorize/issues/new>`_.
 
+.. include:: ../examples/03-incorrect-units-in-source-files/README.rst
 .. include:: ../examples/04-multivariable-input-with-vertical-integration/README.rst

--- a/examples/00-testing-example/pymorize.slurm
+++ b/examples/00-testing-example/pymorize.slurm
@@ -1,8 +1,10 @@
 #!/bin/bash -l
 #SBATCH --job-name=pymorize-controller  # <<< This is the main job, it will launch subjobs if you have Dask enabled.
-#SBATCH --account=ab0246                # <<< Adapt this to your computing account!
+#SBATCH --account=ab0995
 #SBATCH --partition=compute
 #SBATCH --nodes=1
+###############################################################################
+# Prefect settings:
 #SBATCH --time=00:30:00                 # <<< You may need more time, adapt as needed!
 export PREFECT_SERVER_ALLOW_EPHEMERAL_MODE=True
 export PREFECT_SERVER_API_HOST=0.0.0.0
@@ -10,5 +12,6 @@ export PREFECT_SERVER_API_HOST=0.0.0.0
 # https://docs-3.prefect.io/v3/develop/settings-ref#local-storage-path
 export PREFECT_RESULTS_LOCAL_STORAGE_PATH=/scratch/a/${USER}/prefect
 conda activate pymorize
-prefect server start &
+prefect server start -b
 time pymorize process sample.yaml
+prefect server stop

--- a/examples/00-testing-example/sample.yaml
+++ b/examples/00-testing-example/sample.yaml
@@ -5,6 +5,7 @@ general:
   email: "pgierz@awi.de"
   cmor_version: "CMIP6"
   mip: "CMIP"
+  CV_Dir: "/work/ab0246/a270077/SciComp/Projects/pymorize/cmip6-cmor-tables/CMIP6_CVs"
   CMIP_Tables_Dir: "/work/ab0246/a270077/SciComp/Projects/pymorize/cmip6-cmor-tables/Tables"
 pymorize:
   # parallel: True
@@ -71,6 +72,11 @@ pipelines:
       - "pymorize.generic.get_variable"
       - "pymorize.timeaverage.compute_average"
       - "pymorize.units.handle_unit_conversion"
+      # NOTE(PG): Nodes to levels needs to happen early in the pipeline to ensure that
+      #           the setgrid works correctly.
+      - "pymorize.fesom_1p4.nodes_to_levels"
+      - "pymorize.setgrid.setgrid"
+      # - "pymorize.variable_attributes.set_variable_attrs"
       - "pymorize.global_attributes.set_global_attributes"
       - "pymorize.generic.trigger_compute"
       - "pymorize.generic.show_data"

--- a/examples/03-incorrect-units-in-source-files/README.rst
+++ b/examples/03-incorrect-units-in-source-files/README.rst
@@ -1,0 +1,39 @@
+Dealing with wrong input units
+------------------------------
+
+In this example we show how to deal with incorrect units set on the input data. The motivating example comes from the variables
+``dissic`` and ``talk`` for oceanic biogeochemistry:
+
+.. code-block:: json
+    :caption: cmip6-cmor-tables/Tables/CMIP6_Omon.json
+
+        "dissic": {
+            "standard_name": "mole_concentration_of_dissolved_inorganic_carbon_in_sea_water",
+            "units": "mol m-3",
+        },
+        "talk": {
+            "standard_name": "sea_water_alkalinity_expressed_as_mole_equivalent",
+            "units": "mol m-3",
+        },
+
+These two variables need DIC and Talk, which are saved as ``bgc02`` and ``bgc03`` by REcoM. Unfortunately, the ``units`` attribute in the NetCDF
+files is wrong, e.g.:
+
+.. code-block:: bash
+   :caption: Excerpt of ``ncdump -h bgc02_3d.nc``
+
+    float bgc02(time, nodes_3d) ;
+            bgc02:description = "bgc tracer 02" ;
+            bgc02:units = "" ;
+            bgc02:grid_type = "unstructured" ;
+            bgc02:_FillValue = 1.e+30f ;
+
+The actual input unit in both cases is :math:`\frac{mmol}{m^{3}}`, i.e. use ``mult_factor = 1/1e3`` to convert from mmol to mol.
+
+Happily enough, ``pymorize`` provides an easy way to rectify this without needing to edit the source files with something like ``ncatted``. You
+can specify the correct units in the ``model_unit`` setting of the ``rule``. Here is an example of how to do that:
+
+.. literalinclude:: ../../examples/03-incorrect-units-in-source-files/incorrect_units.yaml
+   :language: yaml
+   :linenos:
+   :emphasize-lines: 31, 49

--- a/examples/03-incorrect-units-in-source-files/README.rst
+++ b/examples/03-incorrect-units-in-source-files/README.rst
@@ -33,7 +33,7 @@ The actual input unit in both cases is :math:`\frac{mmol}{m^{3}}`, i.e. use ``mu
 Happily enough, ``pymorize`` provides an easy way to rectify this without needing to edit the source files with something like ``ncatted``. You
 can specify the correct units in the ``model_unit`` setting of the ``rule``. Here is an example of how to do that:
 
-.. literalinclude:: ../../examples/03-incorrect-units-in-source-files/incorrect_units.yaml
+.. literalinclude:: ../examples/03-incorrect-units-in-source-files/incorrect_units.yaml
    :language: yaml
    :linenos:
    :emphasize-lines: 31, 49

--- a/examples/03-incorrect-units-in-source-files/cleanup.py
+++ b/examples/03-incorrect-units-in-source-files/cleanup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Cleans up from example runs
+"""
+import shutil
+from pathlib import Path
+
+
+def rm_file(fname):
+    try:
+        fname.unlink()
+        print(f"Removed file: {fname}")
+    except Exception as e:
+        print(f"Error removing file {fname}: {e}")
+
+
+def rm_dir(dirname):
+    try:
+        shutil.rmtree(dirname)
+        print(f"Removed directory: {dirname}")
+    except Exception as e:
+        print(f"Error removing directory {dirname}: {e}")
+
+
+def cleanup():
+    current_dir = Path.cwd()
+
+    for item in current_dir.rglob("*"):
+        if (
+            item.is_file()
+            and item.name.startswith("slurm")
+            and item.name.endswith("out")
+        ):
+            rm_file(item)
+        if (
+            item.is_file()
+            and item.name.startswith("pymorize")
+            and item.name.endswith("json")
+        ):
+            rm_file(item)
+        if item.is_file() and item.name.endswith("nc"):
+            rm_file(item)
+        if item.name == "pymorize_report.log":
+            rm_file(item)
+        elif item.is_dir() and item.name == "logs":
+            rm_dir(item)
+    print("Cleanup completed.")
+
+
+if __name__ == "__main__":
+    cleanup()

--- a/examples/03-incorrect-units-in-source-files/download-example-data.sh
+++ b/examples/03-incorrect-units-in-source-files/download-example-data.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+#
+# Downloads the example data for this example from DRKZ's Swift object storage
+#
+
+if [ -d model_runs ]; then
+  echo "Example data for $(basename $(pwd)) already downloaded..."
+  exit 0
+fi
+
+module load py-python-swiftclient
+swift download pymorize_demo_data 03 
+tar -xzvf 04-multivariable-input-with-vertical-integration-model-runs.tgz
+rm 04-multivariable-input-with-vertical-integration-model-runs.tgz

--- a/examples/03-incorrect-units-in-source-files/incorrect_units.yaml
+++ b/examples/03-incorrect-units-in-source-files/incorrect_units.yaml
@@ -23,7 +23,7 @@ rules:
     description: "dissic from REcoM, showing missing units in NetCDF"
     inputs:
       - path: "/work/ab0246/a270077/SciComp/Projects/pymorize/examples/03-incorrect-units-in-source-files/model_runs/piControl_LUtrans1850/outdata/recom/"
-        pattern: bgc02_recom_.*.nc
+        pattern: bgc02_fesom_.*.nc
     grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
     mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
     cmor_variable: dissic
@@ -35,13 +35,11 @@ rules:
     source_id: AWI-CM-1-1-HR
     model_component: ocnBgchem
     grid_label: gn
-    pipelines:
-      - default
   - name: Seawater Alkalinity
     description: "talk from REcoM, showing missing units in NetCDF"
     inputs:
       - path: "/work/ab0246/a270077/SciComp/Projects/pymorize/examples/03-incorrect-units-in-source-files/model_runs/piControl_LUtrans1850/outdata/recom/"
-        pattern: bgc03_recom_.*.nc
+        pattern: bgc03_fesom_.*.nc
     grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
     mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
     cmor_variable: talk
@@ -53,5 +51,43 @@ rules:
     source_id: AWI-CM-1-1-HR
     model_component: ocnBgchem
     grid_label: gn
-    pipelines:
-      - default
+distributed:
+  worker:
+    memory:
+      target: 0.6 # Target 60% of worker memory usage
+      spill: 0.7 # Spill to disk when 70% of memory is used
+      pause: 0.8 # Pause workers if memory usage exceeds 80%
+      terminate: 0.95 # Terminate workers at 95% memory usage
+    resources:
+      CPU: 4 # Assign 4 CPUs per worker
+    death-timeout: 600 # Worker timeout if no heartbeat (seconds): Keep workers alive for 5 minutes
+# SLURM-specific settings for launching workers
+jobqueue:
+  slurm:
+    name: pymorize-worker
+    queue: compute # SLURM queue/partition to submit jobs
+    account: ab0246 # SLURM project/account name
+    cores: 4 # Number of cores per worker
+    memory: 128GB # Memory per worker
+    walltime: '00:30:00' # Maximum walltime per job
+    interface: ib0 # Network interface for communication
+    job-extra-directives: # Additional SLURM job options
+      - '--exclusive' # Run on exclusive nodes
+      - '--nodes=1'
+    # Worker template
+    worker-extra:
+      - "--nthreads"
+      - 4
+      - "--memory-limit"
+      - "128GB"
+      - "--lifetime"
+      - "25m"
+      - "--lifetime-stagger"
+      - "4m"
+    # How to launch workers and scheduler
+    job-cpu: 128
+    job-mem: 256GB
+    # worker-command: dask-worker
+    processes: 4 # Limited by memory per worker!
+    # scheduler-command: dask-scheduler
+

--- a/examples/03-incorrect-units-in-source-files/incorrect_units.yaml
+++ b/examples/03-incorrect-units-in-source-files/incorrect_units.yaml
@@ -1,0 +1,57 @@
+general:
+  name: "AWI-ESM-1-1-lr PI Control"
+  description: "CMOR configuration for AWIESM 1.1 LR"
+  maintainer: "pgierz"
+  email: "pgierz@awi.de"
+  cmor_version: "CMIP6"
+  mip: "CMIP"
+  CMIP_Tables_Dir: "/work/ab0246/a270077/SciComp/Projects/pymorize/cmip6-cmor-tables/Tables"
+  CV_Dir: "/work/ab0246/a270077/SciComp/Projects/pymorize/cmip6-cmor-tables/CMIP6_CVs/"
+pymorize:
+  # parallel: True
+  warn_on_no_rule: False
+  use_flox: True
+  dask_cluster: "slurm"
+  dask_cluster_scaling_mode: fixed
+  fixed_jobs: 1
+  # minimum_jobs: 8
+  # maximum_jobs: 30
+  # You can add your own path to the dimensionless mapping table
+  # If nothing is specified here, it will use the built-in one.
+rules:
+  - name: Dissolved Inorganic Carbon in Seawater
+    description: "dissic from REcoM, showing missing units in NetCDF"
+    inputs:
+      - path: "/work/ab0246/a270077/SciComp/Projects/pymorize/examples/03-incorrect-units-in-source-files/model_runs/piControl_LUtrans1850/outdata/recom/"
+        pattern: bgc02_recom_.*.nc
+    grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
+    mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
+    cmor_variable: dissic
+    model_variable: "bgc02"
+    model_unit: "mmol m-3"
+    output_directory: .
+    variant_label: r1i1p1f1
+    experiment_id: piControl
+    source_id: AWI-CM-1-1-HR
+    model_component: ocnBgchem
+    grid_label: gn
+    pipelines:
+      - default
+  - name: Seawater Alkalinity
+    description: "talk from REcoM, showing missing units in NetCDF"
+    inputs:
+      - path: "/work/ab0246/a270077/SciComp/Projects/pymorize/examples/03-incorrect-units-in-source-files/model_runs/piControl_LUtrans1850/outdata/recom/"
+        pattern: bgc03_recom_.*.nc
+    grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
+    mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
+    cmor_variable: talk
+    model_variable: "bgc03"
+    model_unit: "mmol m-3"
+    output_directory: .
+    variant_label: r1i1p1f1
+    experiment_id: piControl
+    source_id: AWI-CM-1-1-HR
+    model_component: ocnBgchem
+    grid_label: gn
+    pipelines:
+      - default

--- a/examples/03-incorrect-units-in-source-files/incorrect_units.yaml
+++ b/examples/03-incorrect-units-in-source-files/incorrect_units.yaml
@@ -90,4 +90,3 @@ jobqueue:
     # worker-command: dask-worker
     processes: 4 # Limited by memory per worker!
     # scheduler-command: dask-scheduler
-

--- a/examples/03-incorrect-units-in-source-files/pymorize.slurm
+++ b/examples/03-incorrect-units-in-source-files/pymorize.slurm
@@ -1,0 +1,18 @@
+#!/bin/bash
+#SBATCH --job-name=pymorize-controller  # <<< This is the main job, it will launch subjobs if you have Dask enabled.
+#SBATCH --account=ab0246                # <<< Adapt this to your computing account!
+#SBATCH --partition=compute
+#SBATCH --nodes=1
+#SBATCH --time=00:30:00                 # <<< You may need more time, adapt as needed!
+export PREFECT_SERVER_ALLOW_EPHEMERAL_MODE=True
+export PREFECT_SERVER_API_HOST=0.0.0.0
+# For more info about Prefect caching, see:
+# https://docs-3.prefect.io/v3/develop/settings-ref#local-storage-path
+export PREFECT_RESULTS_LOCAL_STORAGE_PATH=/scratch/a/${USER}/prefect
+
+module load python3
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate pymorize
+prefect server start -b
+time pymorize process incorrect_units.yaml
+prefect server stop

--- a/src/pymorize/setgrid.py
+++ b/src/pymorize/setgrid.py
@@ -68,7 +68,7 @@ def setgrid(
                 )
         else:
             logger.info(f"{dim=} is not in {da.sizes=}")
-            logger.info(f"Need to check individual sizes...")
+            logger.info("Need to check individual sizes...")
             for name, _size in da.sizes.items():
                 logger.info(f"{name=}, {_size=}")
                 if dimsize == _size:


### PR DESCRIPTION
This pull request introduces several changes across multiple files to enhance functionality, improve logging, and add new examples. The most important changes include updates to the documentation, new example scripts, and improvements to the `setgrid` function.

### Documentation and Examples:

* [`doc/cookbook.rst`](diffhunk://#diff-0208e75066677e1d3f5c18106a5acf10d5c5bcdbf626cbf83efd6ada0e962b03R10): Added a new example to the cookbook documentation.
* [`examples/03-incorrect-units-in-source-files/README.rst`](diffhunk://#diff-3f8caceb2a85df1791ab17e1869b38ed24197b75a3efab7b1a97737f826bac6dR1-R39): Added documentation for dealing with incorrect units in input data.

### Example Scripts:

* [`examples/03-incorrect-units-in-source-files/cleanup.py`](diffhunk://#diff-5b5da58131a666bef708b300b3b1057c62f84c21d6f5bb627667d8225d324a18R1-R51): Added a new script for cleaning up example runs.
* [`examples/03-incorrect-units-in-source-files/download-example-data.sh`](diffhunk://#diff-e093fd3e2f02b0621b381ee0975baf03b29f8aa1454e957134e27822678c33a8R1-R14): Added a new script to download example data.

### Configuration and SLURM Scripts:

* [`examples/00-testing-example/sample.yaml`](diffhunk://#diff-e707464eac69cb4689dbffc675c28f9e94c2b396c6a89e3f9a95ef3c69c1cb1bR8): Added new configuration settings for CV_Dir and pipeline steps. [[1]](diffhunk://#diff-e707464eac69cb4689dbffc675c28f9e94c2b396c6a89e3f9a95ef3c69c1cb1bR8) [[2]](diffhunk://#diff-e707464eac69cb4689dbffc675c28f9e94c2b396c6a89e3f9a95ef3c69c1cb1bR75-R79)
* [`examples/03-incorrect-units-in-source-files/pymorize.slurm`](diffhunk://#diff-4160125a5d4853cdf4395015babb349b17ff78c2874b0245a0783742d5168699R1-R18): Added a new SLURM script for running the pymorize example.

### Code Improvements:

* [`src/pymorize/setgrid.py`](diffhunk://#diff-8e3ca7f63218d7e984e1e564d01a80a819245e87b023326685d3f8b0fa655925R28): Enhanced the `setgrid` function with additional logging to provide more detailed information during execution. [[1]](diffhunk://#diff-8e3ca7f63218d7e984e1e564d01a80a819245e87b023326685d3f8b0fa655925R28) [[2]](diffhunk://#diff-8e3ca7f63218d7e984e1e564d01a80a819245e87b023326685d3f8b0fa655925R50-R77) [[3]](diffhunk://#diff-8e3ca7f63218d7e984e1e564d01a80a819245e87b023326685d3f8b0fa655925R86-R89)