### PR TITLE
Example 1

### DIFF
--- a/doc/cookbook.rst
+++ b/doc/cookbook.rst
@@ -7,4 +7,5 @@ A showcase of some more complicated use cases.
 If you'd like to contribute with your own recipe, or ask for a recipe, please open a
 documentation issue on `our GitHub repository <https://github.com/esm-tools/pymorize/issues/new>`_.
 
+.. include:: ../examples/01-default-unit-conversion/README.rst
 .. include:: ../examples/04-multivariable-input-with-vertical-integration/README.rst

--- a/examples/01-default-unit-conversion/README.rst
+++ b/examples/01-default-unit-conversion/README.rst
@@ -1,0 +1,61 @@
+========================
+Default Unit conversions
+========================
+
+In this example, we show how to do "default unit conversions". ``pymorize`` can handle some standard cases, assuming
+your NetCDF files are sensible. We show two examples:
+
+1. ``mmolC/m2/d`` --> ``kg m-2 s-2``, as in ``fgco2`` for ``CMIP6_Omon.json``:
+
+.. code:: json
+
+        "fgco2": {
+            "frequency": "mon", 
+            "modeling_realm": "ocnBgchem", 
+            "standard_name": "surface_downward_mass_flux_of_carbon_dioxide_expressed_as_carbon", 
+            "units": "kg m-2 s-1", 
+            "cell_methods": "area: mean where sea time: mean", 
+            "cell_measures": "area: areacello", 
+            "long_name": "Surface Downward Mass Flux of Carbon as CO2 [kgC m-2 s-1]", 
+            "comment": "Gas exchange flux of CO2 (positive into ocean)", 
+            "dimensions": "longitude latitude time depth0m", 
+            "out_name": "fgco2", 
+            "type": "real", 
+            "positive": "down", 
+            "valid_min": "", 
+            "valid_max": "", 
+            "ok_min_mean_abs": "", 
+            "ok_max_mean_abs": ""
+        }, 
+
+2. ``µatm`` --> ``Pa``, as in ``spco2`` for ``CMIP6_Omon.json``:
+
+.. code:: json
+
+        "spco2": {
+            "frequency": "mon", 
+            "modeling_realm": "ocnBgchem", 
+            "standard_name": "surface_partial_pressure_of_carbon_dioxide_in_sea_water", 
+            "units": "Pa", 
+            "cell_methods": "area: mean where sea time: mean", 
+            "cell_measures": "area: areacello", 
+            "long_name": "Surface Aqueous Partial Pressure of CO2", 
+            "comment": "The surface called 'surface' means the lower boundary of the atmosphere. The partial pressure of a dissolved gas in sea water is the partial pressure in air with which it would be in equilibrium. The partial pressure of a gaseous constituent of air is the pressure which it alone would exert with unchanged temperature and number of moles per unit volume. The chemical formula for carbon dioxide is CO2.", 
+            "dimensions": "longitude latitude time depth0m", 
+            "out_name": "spco2", 
+            "type": "real", 
+            "positive": "", 
+            "valid_min": "", 
+            "valid_max": "", 
+            "ok_min_mean_abs": "", 
+            "ok_max_mean_abs": ""
+        }, 
+
+
+You can download test data with the provided script::
+
+  $ ./download-example-ata.sh
+
+This extracts ten years of example data for the two variables in questions.
+
+In our configuration file, we don't need to specify anything extra, since the default pipeline can handle these cases.

--- a/examples/01-default-unit-conversion/cleanup.py
+++ b/examples/01-default-unit-conversion/cleanup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Cleans up from example runs
+"""
+import shutil
+from pathlib import Path
+
+
+def rm_file(fname):
+    try:
+        fname.unlink()
+        print(f"Removed file: {fname}")
+    except Exception as e:
+        print(f"Error removing file {fname}: {e}")
+
+
+def rm_dir(dirname):
+    try:
+        shutil.rmtree(dirname)
+        print(f"Removed directory: {dirname}")
+    except Exception as e:
+        print(f"Error removing directory {dirname}: {e}")
+
+
+def cleanup():
+    current_dir = Path.cwd()
+
+    for item in current_dir.rglob("*"):
+        if (
+            item.is_file()
+            and item.name.startswith("slurm")
+            and item.name.endswith("out")
+        ):
+            rm_file(item)
+        if (
+            item.is_file()
+            and item.name.startswith("pymorize")
+            and item.name.endswith("json")
+        ):
+            rm_file(item)
+        if item.is_file() and item.name.endswith("nc"):
+            rm_file(item)
+        if item.name == "pymorize_report.log":
+            rm_file(item)
+        elif item.is_dir() and item.name == "logs":
+            rm_dir(item)
+    print("Cleanup completed.")
+
+
+if __name__ == "__main__":
+    cleanup()

--- a/examples/01-default-unit-conversion/download-example-data.sh
+++ b/examples/01-default-unit-conversion/download-example-data.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+#
+# Downloads the example data for this example from DRKZ's Swift object storage
+#
+
+if [ -d model_runs ]; then
+  echo "Example data for $(basename $(pwd)) already downloaded..."
+  exit 0
+fi
+
+module load py-python-swiftclient
+swift download pymorize_demo 01-default-unit-conversion-model-runs.tgz
+tar -xzvf 01-default-unit-conversion-model-runs.tgz
+rm 01-default-unit-conversion-model-runs.tgz

--- a/examples/01-default-unit-conversion/pymorize.slurm
+++ b/examples/01-default-unit-conversion/pymorize.slurm
@@ -1,0 +1,15 @@
+#!/bin/bash -l
+#SBATCH --job-name=pymorize-controller  # <<< This is the main job, it will launch subjobs if you have Dask enabled.
+#SBATCH --account=ab0246                # <<< Adapt this to your computing account!
+#SBATCH --partition=compute
+#SBATCH --nodes=1
+#SBATCH --time=00:30:00                 # <<< You may need more time, adapt as needed!
+export PREFECT_SERVER_ALLOW_EPHEMERAL_MODE=True
+export PREFECT_SERVER_API_HOST=0.0.0.0
+# For more info about Prefect caching, see:
+# https://docs-3.prefect.io/v3/develop/settings-ref#local-storage-path
+export PREFECT_RESULTS_LOCAL_STORAGE_PATH=/scratch/a/${USER}/prefect
+# loadconda
+conda activate pymorize
+prefect server start -b
+time pymorize process units-example.yaml

--- a/examples/01-default-unit-conversion/units-example.yaml
+++ b/examples/01-default-unit-conversion/units-example.yaml
@@ -26,7 +26,7 @@ rules:
     source_id: AWI-CM-1-1-HR
     model_component: ocnBgchem
     grid_label: gn
-  - name: fgco2
+  - name: spco2
     inputs:
       - path: ./model_runs/piControl_LUtrans1850/outdata/recom/
         pattern: pCO2s_fesom_mon_.*nc

--- a/examples/01-default-unit-conversion/units-example.yaml
+++ b/examples/01-default-unit-conversion/units-example.yaml
@@ -1,0 +1,83 @@
+general:
+  name: "units-example"
+  cmor_version: "CMIP6"
+  mip: "CMIP"
+  CMIP_Tables_Dir: "/work/ab0995/a270243/pymorize/cmip6-cmor-tables/Tables"
+  CV_Dir: "/work/ab0995/a270243/pymorize/cmip6-cmor-tables/CMIP6_CVs"
+pymorize:
+  # parallel: True
+  warn_on_no_rule: False
+  use_flox: True
+  dask_cluster: "slurm"
+  dask_cluster_scaling_mode: fixed
+  fixed_jobs: 12
+rules:
+  - name: fgco2
+    inputs:
+      - path: ./model_runs/piControl_LUtrans1850/outdata/recom/
+        pattern: CO2f_fesom_mon_.*nc
+    cmor_variable: fgco2
+    model_variable: CO2f
+    grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
+    mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
+    output_directory: .
+    variant_label: r1i1p1f1
+    experiment_id: piControl
+    source_id: AWI-CM-1-1-HR
+    model_component: ocnBgchem
+    grid_label: gn
+  - name: fgco2
+    inputs:
+      - path: ./model_runs/piControl_LUtrans1850/outdata/recom/
+        pattern: pCO2s_fesom_mon_.*nc
+    cmor_variable: spco2
+    model_variable: pCO2s
+    grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
+    mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
+    output_directory: .
+    variant_label: r1i1p1f1
+    experiment_id: piControl
+    source_id: AWI-CM-1-1-HR
+    model_component: ocnBgchem
+    grid_label: gn
+
+# Settings for using dask-distributed
+distributed:
+  worker:
+    memory:
+      target: 0.6 # Target 60% of worker memory usage
+      spill: 0.7 # Spill to disk when 70% of memory is used
+      pause: 0.8 # Pause workers if memory usage exceeds 80%
+      terminate: 0.95 # Terminate workers at 95% memory usage
+    resources:
+      CPU: 4 # Assign 4 CPUs per worker
+    death-timeout: 600 # Worker timeout if no heartbeat (seconds): Keep workers alive for 5 minutes
+# SLURM-specific settings for launching workers
+jobqueue:
+  slurm:
+    name: pymorize-worker
+    queue: compute # SLURM queue/partition to submit jobs
+    account: ab0246 # SLURM project/account name
+    cores: 4 # Number of cores per worker
+    memory: 128GB # Memory per worker
+    walltime: '00:30:00' # Maximum walltime per job
+    interface: ib0 # Network interface for communication
+    job-extra-directives: # Additional SLURM job options
+      - '--exclusive' # Run on exclusive nodes
+      - '--nodes=1'
+    # Worker template
+    worker-extra:
+      - "--nthreads"
+      - 4
+      - "--memory-limit"
+      - "128GB"
+      - "--lifetime"
+      - "25m"
+      - "--lifetime-stagger"
+      - "4m"
+    # How to launch workers and scheduler
+    job-cpu: 128
+    job-mem: 256GB
+    # worker-command: dask-worker
+    processes: 4 # Limited by memory per worker!
+    # scheduler-command: dask-scheduler


### PR DESCRIPTION
This pull request includes several additions and updates to the `examples/01-default-unit-conversion` directory, which demonstrate default unit conversions using `pymorize`. The changes include new documentation, scripts, and configuration files.

### Documentation and Examples:

* Added a new section to `doc/cookbook.rst` to include the `examples/01-default-unit-conversion/README.rst` file, which provides detailed examples of default unit conversions (`mmolC/m2/d` to `kg m-2 s-1` and `µatm` to `Pa`). [[1]](diffhunk://#diff-0208e75066677e1d3f5c18106a5acf10d5c5bcdbf626cbf83efd6ada0e962b03R10) [[2]](diffhunk://#diff-7b91a93e794c6212a562121a3e61e394e0668d14beef42f484c70616ddf1b343R1-R61)

### Scripts:

* Added `cleanup.py` script to clean up files generated during example runs. This script removes specific files and directories based on their names and extensions.
* Added `download-example-data.sh` script to download example data from DRKZ's Swift object storage, extract the data, and remove the downloaded archive.

### Configuration:

* Added `pymorize.slurm` script to configure and submit a SLURM job for running `pymorize` with Prefect server settings and conda environment activation.
* Added `units-example.yaml` configuration file to define the general settings, rules for processing variables, and distributed computing settings for the example.