### PR TITLE
CI: Better Job separation

### DIFF
--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -78,27 +78,27 @@ jobs:
           export NETCDF_DEBUG=1
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/meta/*.py --cov-report=xml:coverage-meta.xml
+          pytest -vvv -s --cov tests/meta/*.py --cov-report=xml:coverage-meta.xml --cov-report=json:coverage-meta.json
       - name: Test with pytest (Unit)
         run: |
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/unit/*.py --cov-report=xml:coverage-unit1.xml
-          pytest -vvv -s --cov tests/unit/data_request/*.py --cov-report=xml:coverage-unit2.xml
+          pytest -vvv -s --cov tests/unit/*.py --cov-report=xml:coverage-unit1.xml --cov-report=json:coverage-unit1.json
+          pytest -vvv -s --cov tests/unit/data_request/*.py --cov-report=xml:coverage-unit2.xml --cov-report=json:coverage-unit2.json
       - name: Test with pytest (Integration)
         run: |
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/integration/*.py --cov-report=xml:coverage-integration.xml
+          pytest -vvv -s --cov tests/integration/*.py --cov-report=xml:coverage-integration.xml --cov-report=json:coverage-integration.json
       - name: Test with doctest
         run: |
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          PYTHONPATH=src pytest -v --doctest-modules src/ --cov=src/pymorize --cov-report=xml:coverage-doctest.xml
+          PYTHONPATH=src pytest -v --doctest-modules src/ --cov=src/pymorize --cov-report=xml:coverage-doctest.xml --cov-report=json:coverage-doctest.json
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         with:
           name: coverage-reports-${{ matrix.python-version }}
-          path: coverage-*.xml
+          path: coverage-*.json
 
   # Combined test coverage report
   coverage:
@@ -126,12 +126,28 @@ jobs:
 
           # Process each Python version separately
           for version in 3.9 3.10 3.11 3.12; do
-            # Combine coverage files for this version
-            find coverage-reports/coverage-reports-$version/ -name "*.xml" -exec python -m coverage combine {} \;
-            # Generate XML report for this version
-            python -m coverage xml -o coverage-output/$version/coverage.xml
-            # Reset coverage data for next version
-            python -m coverage erase
+            # Create a temporary directory for this version's JSON files
+            mkdir -p temp-$version
+
+            # Extract JSON files for this version
+            find coverage-reports/coverage-reports-$version/ -name "*.json" -exec cp {} temp-$version/ \;
+
+            # Process the coverage data
+            cd temp-$version
+            # Convert each JSON file to a .coverage data file and then combine them
+            for json_file in *.json; do
+              # Create a unique name for each .coverage file
+              coverage_file=".coverage.$(basename $json_file .json)"
+              python -c "import json, coverage; data = json.load(open('$json_file')); cov = coverage.Coverage(); cov.data.add_file_tracers(data['files']); cov.save('$coverage_file')"
+            done
+            # Combine all the .coverage files
+            python -m coverage combine
+            # Generate XML report
+            python -m coverage xml -o ../coverage-output/$version/coverage.xml
+            cd ..
+
+            # Clean up temporary directory
+            rm -rf temp-$version
           done
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -129,9 +129,10 @@ jobs:
             cp coverage-reports/coverage-reports-$version/coverage-$version.xml coverage-output/$version/coverage.xml
           done
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           directory: ./coverage-output/
           fail_ci_if_error: false
           flags: python-3.9,python-3.10,python-3.11,python-3.12
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: esm-tools/pymorize

--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -5,8 +5,49 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+
 jobs:
+  # Setup job for linting and formatting checks
+  lint_and_format:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install black flake8 pytest isort yamllint
+      - name: Install package for linting
+        run: |
+          python -m pip install .[dev]
+      - name: Lint with flake8 (syntax errors only)
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Run full flake8 check
+        run: |
+          # stop at any error
+          flake8 . --show-source --statistics --exclude ./cmip6-cmor-tables,./build,_version.py,./src/pymorize/webapp.py,./CMIP7_DReq_Software
+      - name: Run isort
+        run: |
+          isort --profile black --check --skip ./cmip6-cmor-tables --skip ./versioneer.py --skip ./CMIP7_DReq_Software .
+      - name: Run black
+        run: |
+          black --check --extend-exclude 'cmip6-cmor-tables|CMIP7_DReq_Software|versioneer\.py|webapp\.py' .
+      - name: Run yamllint
+        run: |
+          yamllint .
+
+  # Main test job that runs on multiple Python versions
   test:
+    name: Test Python ${{ matrix.python-version }}
+    needs: [lint_and_format]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -31,18 +72,6 @@ jobs:
       - name: Install package
         run: |
           python -m pip install ".[dev, fesom]"
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      # - name: Check internet connectivity of CI runner
-      #   run: |
-      #     sudo apt-get install -y curl
-      #     curl -s  https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | sudo bash
-      #     sudo apt-get install -y speedtest
-      #     speedtest --accept-license
       - name: Test if data will work (Meta-Test)
         run: |
           export HDF5_DEBUG=1
@@ -65,47 +94,32 @@ jobs:
         run: |
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
           PYTHONPATH=src pytest -v --doctest-modules src/
-  check_format:
+
+  # Combined test coverage report
+  coverage:
+    name: Generate Coverage Report
+    needs: test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
+      - name: Set up NetCDF4 with HDF5 support
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libnetcdf-dev libhdf5-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install black
-          python -m pip install flake8 pytest
-          python -m pip install isort
-          python -m pip install yamllint
-          if ${{ matrix.python-version == '3.12' }}; then
-            pip install --upgrade setuptools
-          fi
-      - name: Install package
+          python -m pip install pytest pytest-cov coverage
+          python -m pip install ".[dev, fesom]"
+      - name: Generate coverage report
         run: |
-          python -m pip install .[dev]
-      - name: Run isort
-        run: |
-          isort --profile black --check --skip ./cmip6-cmor-tables --skip ./versioneer.py --skip ./CMIP7_DReq_Software .
-      - name: Lint with flake8
-        run: |
-          ## stop the build if there are Python syntax errors or undefined names
-          #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          ## exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-          # stop at any error
-          flake8 . --show-source --statistics --exclude ./cmip6-cmor-tables,./build,_version.py,./src/pymorize/webapp.py,./CMIP7_DReq_Software
-      - name: Run black
-        run: |
-          black --check --extend-exclude 'cmip6-cmor-tables|CMIP7_DReq_Software|versioneer\.py|webapp\.py' .
-      - name: yamllint
-        run: |
-          yamllint .
+          pytest --cov=src/pymorize --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -95,7 +95,7 @@ jobs:
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
           PYTHONPATH=src pytest -v --doctest-modules src/ --cov=src/pymorize --cov-report=xml:coverage-doctest.xml
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports-${{ matrix.python-version }}
           path: coverage-*.xml
@@ -116,7 +116,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-cov coverage
       - name: Download coverage reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: coverage-reports
       - name: Process coverage reports

--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -78,22 +78,27 @@ jobs:
           export NETCDF_DEBUG=1
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/meta/*.py
+          pytest -vvv -s --cov tests/meta/*.py --cov-report=xml:coverage-meta.xml
       - name: Test with pytest (Unit)
         run: |
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/unit/*.py
-          pytest -vvv -s --cov tests/unit/data_request/*.py
+          pytest -vvv -s --cov tests/unit/*.py --cov-report=xml:coverage-unit1.xml
+          pytest -vvv -s --cov tests/unit/data_request/*.py --cov-report=xml:coverage-unit2.xml
       - name: Test with pytest (Integration)
         run: |
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/integration/*.py
+          pytest -vvv -s --cov tests/integration/*.py --cov-report=xml:coverage-integration.xml
       - name: Test with doctest
         run: |
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          PYTHONPATH=src pytest -v --doctest-modules src/
+          PYTHONPATH=src pytest -v --doctest-modules src/ --cov=src/pymorize --cov-report=xml:coverage-doctest.xml
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-reports-${{ matrix.python-version }}
+          path: coverage-*.xml
 
   # Combined test coverage report
   coverage:
@@ -106,20 +111,31 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-      - name: Set up NetCDF4 with HDF5 support
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libnetcdf-dev libhdf5-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-cov coverage
-          python -m pip install ".[dev, fesom]"
-      - name: Generate coverage report
+      - name: Download coverage reports
+        uses: actions/download-artifact@v3
+        with:
+          path: coverage-reports
+      - name: Process coverage reports
         run: |
-          pytest --cov=src/pymorize --cov-report=xml
-      - name: Upload coverage to Codecov
+          # Create directories for each Python version
+          mkdir -p coverage-output/3.9 coverage-output/3.10 coverage-output/3.11 coverage-output/3.12
+
+          # Process each Python version separately
+          for version in 3.9 3.10 3.11 3.12; do
+            # Combine coverage files for this version
+            find coverage-reports/coverage-reports-$version/ -name "*.xml" -exec python -m coverage combine {} \;
+            # Generate XML report for this version
+            python -m coverage xml -o coverage-output/$version/coverage.xml
+            # Reset coverage data for next version
+            python -m coverage erase
+          done
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml
+          directory: ./coverage-output/
           fail_ci_if_error: false
+          flags: python-3.9,python-3.10,python-3.11,python-3.12

--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
 jobs:
   # Setup job for linting and formatting checks
   lint_and_format:
@@ -43,7 +42,6 @@ jobs:
       - name: Run yamllint
         run: |
           yamllint .
-
   # Main test job that runs on multiple Python versions
   test:
     name: Test Python ${{ matrix.python-version }}
@@ -102,7 +100,6 @@ jobs:
         with:
           name: coverage-reports-${{ matrix.python-version }}
           path: coverage-${{ matrix.python-version }}.xml
-
   # Combined test coverage report
   coverage:
     name: Generate Coverage Report
@@ -137,3 +134,4 @@ jobs:
           directory: ./coverage-output/
           fail_ci_if_error: false
           flags: python-3.9,python-3.10,python-3.11,python-3.12
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI-test.yaml
+++ b/.github/workflows/CI-test.yaml
@@ -78,27 +78,30 @@ jobs:
           export NETCDF_DEBUG=1
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/meta/*.py --cov-report=xml:coverage-meta.xml --cov-report=json:coverage-meta.json
+          pytest -vvv -s --cov=src/pymorize tests/meta/*.py
       - name: Test with pytest (Unit)
         run: |
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/unit/*.py --cov-report=xml:coverage-unit1.xml --cov-report=json:coverage-unit1.json
-          pytest -vvv -s --cov tests/unit/data_request/*.py --cov-report=xml:coverage-unit2.xml --cov-report=json:coverage-unit2.json
+          pytest -vvv -s --cov=src/pymorize --cov-append tests/unit/*.py
+          pytest -vvv -s --cov=src/pymorize --cov-append tests/unit/data_request/*.py
       - name: Test with pytest (Integration)
         run: |
           export XARRAY_ENGINE=h5netcdf
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          pytest -vvv -s --cov tests/integration/*.py --cov-report=xml:coverage-integration.xml --cov-report=json:coverage-integration.json
+          pytest -vvv -s --cov=src/pymorize --cov-append tests/integration/*.py
       - name: Test with doctest
         run: |
           export PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS=300
-          PYTHONPATH=src pytest -v --doctest-modules src/ --cov=src/pymorize --cov-report=xml:coverage-doctest.xml --cov-report=json:coverage-doctest.json
+          PYTHONPATH=src pytest -v --doctest-modules --cov=src/pymorize --cov-append src/
+      - name: Generate coverage report
+        run: |
+          python -m coverage xml -o coverage-${{ matrix.python-version }}.xml
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         with:
           name: coverage-reports-${{ matrix.python-version }}
-          path: coverage-*.json
+          path: coverage-${{ matrix.python-version }}.xml
 
   # Combined test coverage report
   coverage:
@@ -124,30 +127,9 @@ jobs:
           # Create directories for each Python version
           mkdir -p coverage-output/3.9 coverage-output/3.10 coverage-output/3.11 coverage-output/3.12
 
-          # Process each Python version separately
+          # Copy coverage reports to their respective directories
           for version in 3.9 3.10 3.11 3.12; do
-            # Create a temporary directory for this version's JSON files
-            mkdir -p temp-$version
-
-            # Extract JSON files for this version
-            find coverage-reports/coverage-reports-$version/ -name "*.json" -exec cp {} temp-$version/ \;
-
-            # Process the coverage data
-            cd temp-$version
-            # Convert each JSON file to a .coverage data file and then combine them
-            for json_file in *.json; do
-              # Create a unique name for each .coverage file
-              coverage_file=".coverage.$(basename $json_file .json)"
-              python -c "import json, coverage; data = json.load(open('$json_file')); cov = coverage.Coverage(); cov.data.add_file_tracers(data['files']); cov.save('$coverage_file')"
-            done
-            # Combine all the .coverage files
-            python -m coverage combine
-            # Generate XML report
-            python -m coverage xml -o ../coverage-output/$version/coverage.xml
-            cd ..
-
-            # Clean up temporary directory
-            rm -rf temp-$version
+            cp coverage-reports/coverage-reports-$version/coverage-$version.xml coverage-output/$version/coverage.xml
           done
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/tests/externals/test_pyfesom2.py
+++ b/tests/externals/test_pyfesom2.py
@@ -4,13 +4,13 @@ Tests for pyfesom2 functionality as used in pymorize
 
 from pyfesom2.load_mesh_data import load_mesh
 
-import pymorize.rule
+import pymorize.core.rule
 
 
 def test_read_grid_from_rule(fesom_pi_mesh_config):
     config = fesom_pi_mesh_config
     mesh_path = config["inherit"]["mesh_file"]
-    rule = pymorize.rule.Rule.from_dict(config["rules"][0])
+    rule = pymorize.core.rule.Rule.from_dict(config["rules"][0])
     rule.mesh_file = config["inherit"]["mesh_file"]
 
     load_mesh(mesh_path)


### PR DESCRIPTION
This pull request makes significant updates to the CI workflow configuration in the `.github/workflows/CI-test.yaml` file. The changes include adding a new job for linting and formatting checks, restructuring the test jobs to include dependencies on the linting job, and adding a new job for generating and uploading a test coverage report.

Key changes include:

### Linting and Formatting:
* Added a new `lint_and_format` job to perform linting and formatting checks using `flake8`, `isort`, `black`, and `yamllint`. This ensures that the code adheres to the project's style guidelines before running tests.

### Test Job Restructuring:
* Modified the `test` job to depend on the `lint_and_format` job, ensuring that linting and formatting checks pass before running tests.

### Coverage Reporting:
* Added a new `coverage` job to generate a test coverage report using `pytest-cov` and upload the report to Codecov. This helps in tracking the test coverage of the codebase.