### PR TITLE
ci: codecod

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: yes
+
+ignore:
+  - "src/pymorize/_version.py"
+  - "cmip6-cmor-tables/**/*"
+  - "CMIP7_DReq_Software/**/*"
+  - "versioneer.py"
+  - "setup.py"
+  - "reload_sphinx.py"
+  - "conftest.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,10 @@
 codecov:
   require_ci_to_pass: yes
-
+coverage:
+  status:
+    project:
+      default:
+        threshold: 10% # Allow ten percent coverage decreases (a bit high, but that's fine for now...)
 ignore:
   - "src/pymorize/_version.py"
   - "cmip6-cmor-tables/**/*"


### PR DESCRIPTION
## Blockers
+ [ ] #145 

## Copilot Summary
This pull request includes updates to the `codecov.yml` configuration file to improve code coverage reporting by requiring CI to pass and ignoring specific files and directories.

Changes to `codecov.yml`:

* Added a requirement for CI to pass before code coverage is reported.
* Ignored the following files and directories to exclude them from code coverage reports:
  - `src/pymorize/_version.py`
  - `cmip6-cmor-tables/**/*`
  - `CMIP7_DReq_Software/**/*`
  - `versioneer.py`
  - `setup.py`
  - `reload_sphinx.py`
  - `conftest.py`