### PR TITLE
Examples with new structure

### DIFF
--- a/examples/00-testing-example/sample.yaml
+++ b/examples/00-testing-example/sample.yaml
@@ -68,19 +68,19 @@ rules:
 pipelines:
   - name: default
     steps:
-      - "pymorize.gather_inputs.load_mfdataset"
-      - "pymorize.generic.get_variable"
-      - "pymorize.timeaverage.compute_average"
-      - "pymorize.units.handle_unit_conversion"
+      - "pymorize.core.gather_inputs.load_mfdataset"
+      - "pymorize.std_lib.get_variable"
+      - "pymorize.std_lib.time_average"
+      - "pymorize.std_lib.convert_units"
       # NOTE(PG): Nodes to levels needs to happen early in the pipeline to ensure that
       #           the setgrid works correctly.
       - "pymorize.fesom_1p4.nodes_to_levels"
-      - "pymorize.setgrid.setgrid"
+      - "pymorize.std_lib.setgrid.setgrid"
       # - "pymorize.variable_attributes.set_variable_attrs"
-      - "pymorize.global_attributes.set_global_attributes"
-      - "pymorize.generic.trigger_compute"
-      - "pymorize.generic.show_data"
-      - "pymorize.files.save_dataset"
+      - "pymorize.std_lib.set_global_attributes"
+      - "pymorize.std_lib.trigger_compute"
+      - "pymorize.std_lib.show_data"
+      - "pymorize.std_lib.files.save_dataset"
 # Settings for using dask-distributed
 distributed:
   worker:

--- a/examples/01-default-unit-conversion/units-example.yaml
+++ b/examples/01-default-unit-conversion/units-example.yaml
@@ -40,7 +40,6 @@ rules:
     source_id: AWI-CM-1-1-HR
     model_component: ocnBgchem
     grid_label: gn
-
 # Settings for using dask-distributed
 distributed:
   worker:

--- a/examples/02-upward-ocean-mass-transport/wo_cellarea.yaml
+++ b/examples/02-upward-ocean-mass-transport/wo_cellarea.yaml
@@ -31,17 +31,17 @@ rules:
 pipelines:
   - name: default
     steps:
-      - "pymorize.gather_inputs.load_mfdataset"
-      - "pymorize.generic.get_variable"
+      - "pymorize.core.gather_inputs.load_mfdataset"
+      - "pymorize.std_lib.get_variable"
       - "script://./wo_cellarea.py:nodes_to_levels"
-      - "pymorize.timeaverage.compute_average"
+      - "pymorize.std_lib.time_average"
       - "script://./wo_cellarea.py:weight_by_cellarea_and_density"
-      - "pymorize.unity.handle_unit_conversion"
-      - "pymorize.setgrid.setgrid"
-      - "pymorize.global_attributes.set_global_attributes"
-      - "pymorize.generic.trigger_compute"
-      - "pymorize.generic.show_data"
-      - "pymorize.files.save_dataset"
+      - "pymorize.std_lib.convert_units"
+      - "pymorize.std_lib.setgrid.setgrid"
+      - "pymorize.std_lib.set_global_attributes"
+      - "pymorize.std_lib.trigger_compute"
+      - "pymorize.std_lib.show_data"
+      - "pymorize.std_lib.files.save_dataset"
 # Settings for using dask-distributed
 distributed:
   worker:

--- a/examples/03-incorrect-units-in-source-files/download-example-data.sh
+++ b/examples/03-incorrect-units-in-source-files/download-example-data.sh
@@ -9,6 +9,6 @@ if [ -d model_runs ]; then
 fi
 
 module load py-python-swiftclient
-swift download pymorize_demo_data 03 
-tar -xzvf 04-multivariable-input-with-vertical-integration-model-runs.tgz
-rm 04-multivariable-input-with-vertical-integration-model-runs.tgz
+swift download pymorize_demo_data 03-incorrect-units-in-source-files-model-runs.tgz 
+tar -xzvf 03-incorrect-units-in-source-files-model-runs.tgz 
+rm 03-incorrect-units-in-source-files-model-runs.tgz 

--- a/examples/04-multivariable-input-with-vertical-integration/multivariable_vertical_integration_example.yaml
+++ b/examples/04-multivariable-input-with-vertical-integration/multivariable_vertical_integration_example.yaml
@@ -42,17 +42,17 @@ rules:
 pipelines:
   - name: default
     steps:
-      - "pymorize.gather_inputs.load_mfdataset"
+      - "pymorize.core.gather_inputs.load_mfdataset"
       - "script://./intpp_recom.py:add_pp_components"
       - "pymorize.fesom_1p4.nodes_to_levels"
       - "script://./intpp_recom.py:vertical_integration"
       - "script://./intpp_recom.py:set_pp_units"
-      - "pymorize.units.handle_unit_conversion"
-      - "pymorize.timeaverage.compute_average"
-      - "pymorize.global_attributes.set_global_attributes"
-      - "pymorize.generic.trigger_compute"
-      - "pymorize.generic.show_data"
-      - "pymorize.files.save_dataset"
+      - "pymorize.std_lib.convert_units"
+      - "pymorize.std_lib.time_average"
+      - "pymorize.std_lib.set_global_attributes"
+      - "pymorize.std_lib.trigger_compute"
+      - "pymorize.std_lib.show_data"
+      - "pymorize.std_lib.files.save_dataset"
 # Settings for using dask-distributed
 distributed:
   worker:


### PR DESCRIPTION
Changes the examples to use the new structure of `std_lib` in the pipeline steps.

Closes #132
