### PR TITLE
Fix: Examples with new structure

### DIFF
--- a/examples/01-default-unit-conversion/pymorize.slurm
+++ b/examples/01-default-unit-conversion/pymorize.slurm
@@ -9,7 +9,9 @@ export PREFECT_SERVER_API_HOST=0.0.0.0
 # For more info about Prefect caching, see:
 # https://docs-3.prefect.io/v3/develop/settings-ref#local-storage-path
 export PREFECT_RESULTS_LOCAL_STORAGE_PATH=/scratch/a/${USER}/prefect
-# loadconda
+# Load conda
+module load python3
+source $(conda info --base)/etc/profile.d/conda.sh
 conda activate pymorize
 prefect server start -b
 time pymorize process units-example.yaml

--- a/examples/02-upward-ocean-mass-transport/pymorize_wo_cellarea.slurm
+++ b/examples/02-upward-ocean-mass-transport/pymorize_wo_cellarea.slurm
@@ -10,6 +10,8 @@ export PREFECT_SERVER_API_HOST=0.0.0.0
 # https://docs-3.prefect.io/v3/develop/settings-ref#local-storage-path
 export PREFECT_RESULTS_LOCAL_STORAGE_PATH=/scratch/a/${USER}/prefect
 # loadconda
+module load python3
+source $(conda info --base)/etc/profile.d/conda.sh
 conda activate pymorize
 prefect server start -b
 time pymorize process wo_cellarea.yaml

--- a/examples/02-upward-ocean-mass-transport/wo_cellarea.py
+++ b/examples/02-upward-ocean-mass-transport/wo_cellarea.py
@@ -21,7 +21,7 @@ Step.2 Apply cell_area calculations
 import xarray as xr
 
 import pymorize.fesom_1p4
-from pymorize.units import ureg
+from pymorize.std_lib.units import ureg
 
 
 def nodes_to_levels(data, rule):

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,8 @@ setup(
             "pymorize=pymorize.cli:main",
         ],
         "pymorize.cli_subcommands": [
-            "plugins=pymorize.plugins:plugins",
-            "externals=pymorize.externals:externals",
+            "plugins=pymorize.core.plugins:plugins",
+            "externals=pymorize.core.externals:externals",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
This pull request includes updates to improve environment setup, modify import paths, and adjust plugin configurations. The most important changes are categorized as follows:

### Environment Setup Improvements:
* Updated `pymorize.slurm` scripts to load Python 3 and initialize Conda environments explicitly before activating `pymorize`. This ensures consistent environment setup for Prefect workflows. (`examples/01-default-unit-conversion/pymorize.slurm`, `examples/02-upward-ocean-mass-transport/pymorize_wo_cellarea.slurm`) [[1]](diffhunk://#diff-02e56c0c86880ac8c526de075d7fcec21b66321dcface2ea48d86b6cbc1b89b1L12-R14) [[2]](diffhunk://#diff-c7a037e204c330794ebfa642ad0d205c03c7c41c6e1dfd7d3e9c0e606e7c8496R13-R14)

### Codebase Organization:
* Updated import paths in `wo_cellarea.py` to reflect a new module structure, changing the import of `ureg` to use `pymorize.std_lib.units` instead of `pymorize.units`. (`examples/02-upward-ocean-mass-transport/wo_cellarea.py`)
* Modified `setup.py` to update plugin and external command paths, moving them from `pymorize.plugins` and `pymorize.externals` to `pymorize.core.plugins` and `pymorize.core.externals`, aligning with a reorganized directory structure. (`setup.py`)