### PR TITLE
test: improved cache downloads

### DIFF
--- a/tests/fixtures/example_data/awicm_recom.py
+++ b/tests/fixtures/example_data/awicm_recom.py
@@ -1,44 +1,27 @@
 """Example data for the FESOM model."""
 
 import os
-import tarfile
-from pathlib import Path
 
 import pytest
-import requests
+
+from .shared_cache import download_file, extract_tarfile
 
 URL = "https://nextcloud.awi.de/s/DaQjtTS9xB7o7pL/download/awicm_1p0_recom.tar"
 """str : URL to download the example data from."""
 
 
 @pytest.fixture(scope="session")
-def awicm_1p0_recom_download_data(tmp_path_factory):
-    cache_dir = tmp_path_factory.getbasetemp() / "cached_data"
-    cache_dir.mkdir(exist_ok=True)
-    data_path = cache_dir / "awicm_1p0_recom.tar"
-
-    if not data_path.exists():
-        response = requests.get(URL)
-        response.raise_for_status()
-        with open(data_path, "wb") as f:
-            f.write(response.content)
-        print(f"Data downloaded: {data_path}.")
-    else:
-        print(f"Using cached data: {data_path}.")
-
-    return data_path
+def awicm_1p0_recom_download_data():
+    # Use shared cache instead of tmp_path_factory
+    return download_file(URL, "awicm_1p0_recom.tar")
 
 
 @pytest.fixture(scope="session")
 def awicm_1p0_recom_data(awicm_1p0_recom_download_data):
-    data_dir = Path(awicm_1p0_recom_download_data).parent / "awicm_1p0_recom"
-    if not data_dir.exists():
-        with tarfile.open(awicm_1p0_recom_download_data, "r") as tar:
-            tar.extractall(data_dir)
-        print(f"Data extracted to: {data_dir}.")
-    else:
-        print(f"Using cached extraction: {data_dir}.")
+    # Extract to shared location
+    data_dir = extract_tarfile(awicm_1p0_recom_download_data)
 
+    # Debug logging
     for root, dirs, files in os.walk(data_dir):
         print(f"Root: {root}")
         for file in files:

--- a/tests/fixtures/example_data/fesom_2p6_pimesh.py
+++ b/tests/fixtures/example_data/fesom_2p6_pimesh.py
@@ -1,73 +1,52 @@
 """Example data for the FESOM model."""
 
 import shutil
-import tarfile
 from pathlib import Path
 
 import pytest
-import requests
+
+from .shared_cache import download_file, extract_tarfile
 
 URL = "https://nextcloud.awi.de/s/AL2cFQx5xGE473S/download/fesom_2p6_pimesh.tar"
 """str : URL to download the example data from."""
 
 
 @pytest.fixture(scope="session")
-def fesom_2p6_esm_tools_download_data(tmp_path_factory):
-    cache_dir = tmp_path_factory.getbasetemp() / "cached_data"
-    cache_dir.mkdir(exist_ok=True)
-    data_path = cache_dir / "fesom_2p6_pimesh.tar"
-
-    if not data_path.exists():
-        response = requests.get(URL)
-        response.raise_for_status()
-        with open(data_path, "wb") as f:
-            f.write(response.content)
-        print(f"Data downloaded: {data_path}.")
-    else:
-        print(f"Using cached data: {data_path}.")
-
-    return data_path
+def fesom_2p6_esm_tools_download_data():
+    # Use shared cache instead of tmp_path_factory
+    return download_file(URL, "fesom_2p6_pimesh.tar")
 
 
 @pytest.fixture(scope="session")
 def fesom_2p6_pimesh_esm_tools_data(fesom_2p6_esm_tools_download_data):
-    I_need_to_make_a_local_copy = True
-    # Check if you have a local copy
-    # Useful for testing on your local laptop
-    local_cache_path = Path("~/.cache/pytest/github.com/esm-tools/pymor").expanduser()
-    local_cache_path = local_cache_path / "fesom_2p6_pimesh"
+    # Check if we have a local copy in the user's home directory
+    # This is useful for testing on a local laptop
+    local_cache_path = (
+        Path("~/.cache/pytest/github.com/esm-tools/pymor").expanduser()
+        / "fesom_2p6_pimesh"
+    )
     if local_cache_path.exists():
-        I_need_to_make_a_local_copy = False
         print(f"Using local cache: {local_cache_path}")
         return local_cache_path
-    data_dir = Path(fesom_2p6_esm_tools_download_data).parent / "fesom_2p6_pimesh"
-    if not data_dir.exists():
-        with tarfile.open(fesom_2p6_esm_tools_download_data, "r") as tar:
-            tar.extractall(data_dir)
-        print(f"Data extracted to: {data_dir}.")
-    else:
-        print(f"Using cached extraction: {data_dir}.")
 
-    # for root, dirs, files in os.walk(data_dir):
-    #     print(f"Root: {root}")
-    #     for file in files:
-    #         print(f"File: {os.path.join(root, file)}")
+    # Extract to shared location
+    data_dir = extract_tarfile(fesom_2p6_esm_tools_download_data)
 
-    # print(f">>> RETURNING: {data_dir / 'fesom_2p6_pimesh' }")
-    if I_need_to_make_a_local_copy:
+    # Try to create a local copy for faster access in future runs
+    try:
         local_cache_path.mkdir(parents=True, exist_ok=True)
-        try:
-            shutil.copytree(
-                data_dir / "fesom_2p6_pimesh",
-                local_cache_path,
-                dirs_exist_ok=True,
-                ignore_dangling_symlinks=True,
-            )
-            # (data_dir / "fesom_2p6_pimesh").copy(local_cache_path, follow_symlinks=True)
-            print(f"Local cache created: {local_cache_path}")
-        except Exception as e:
-            print(f"Failed to create local cache: {e}")
-            # Remove the local cache
+        shutil.copytree(
+            data_dir / "fesom_2p6_pimesh",
+            local_cache_path,
+            dirs_exist_ok=True,
+            ignore_dangling_symlinks=True,
+        )
+        print(f"Local cache created: {local_cache_path}")
+    except Exception as e:
+        print(f"Failed to create local cache: {e}")
+        # Remove the local cache if it failed
+        if local_cache_path.exists():
             shutil.rmtree(local_cache_path)
+
     print(f">>> RETURNING: {data_dir / 'fesom_2p6_pimesh' }")
     return data_dir / "fesom_2p6_pimesh"

--- a/tests/fixtures/example_data/pi_uxarray.py
+++ b/tests/fixtures/example_data/pi_uxarray.py
@@ -1,10 +1,8 @@
 """Example data for the FESOM model."""
 
-import tarfile
-from pathlib import Path
-
 import pytest
-import requests
+
+from .shared_cache import download_file, extract_tarfile
 
 URL = "https://nextcloud.awi.de/s/swqyFgbL2jjgjRo/download/pi_uxarray.tar"
 """str : URL to download the example data from."""
@@ -14,55 +12,26 @@ MESH_URL = "https://nextcloud.awi.de/s/FCPZmBJGeGaji4y/download/pi_mesh.tgz"
 
 
 @pytest.fixture(scope="session")
-def pi_uxarray_download_data(tmp_path_factory):
-    cache_dir = tmp_path_factory.getbasetemp() / "cached_data"
-    cache_dir.mkdir(exist_ok=True)
-    data_path = cache_dir / "pi_uxarray.tar"
-
-    if not data_path.exists():
-        response = requests.get(URL)
-        response.raise_for_status()
-        with open(data_path, "wb") as f:
-            f.write(response.content)
-        print(f"Data downloaded: {data_path}.")
-    else:
-        print(f"Using cached data: {data_path}.")
-
-    return data_path
+def pi_uxarray_download_data():
+    # Use shared cache instead of tmp_path_factory
+    return download_file(URL, "pi_uxarray.tar")
 
 
 @pytest.fixture(scope="session")
 def pi_uxarray_data(pi_uxarray_download_data):
-
-    data_dir = Path(pi_uxarray_download_data).parent
-    with tarfile.open(pi_uxarray_download_data, "r") as tar:
-        tar.extractall(data_dir)
-
-    return data_dir / "pi_uxarray"
+    # Extract to shared location
+    data_dir = extract_tarfile(pi_uxarray_download_data, subfolder="pi_uxarray")
+    return data_dir
 
 
 @pytest.fixture(scope="session")
-def pi_uxarray_download_mesh(tmp_path_factory):
-    cache_dir = tmp_path_factory.getbasetemp() / "cached_data"
-    cache_dir.mkdir(exist_ok=True)
-    data_path = cache_dir / "pi_mesh.tar"
-
-    if not data_path.exists():
-        response = requests.get(MESH_URL)
-        response.raise_for_status()
-        with open(data_path, "wb") as f:
-            f.write(response.content)
-        print(f"Data downloaded: {data_path}.")
-    else:
-        print(f"Using cached data: {data_path}.")
-
-    return data_path
+def pi_uxarray_download_mesh():
+    # Use shared cache instead of tmp_path_factory
+    return download_file(MESH_URL, "pi_mesh.tgz")
 
 
 @pytest.fixture(scope="session")
 def pi_uxarray_mesh(pi_uxarray_download_mesh):
-    data_dir = Path(pi_uxarray_download_mesh).parent
-    with tarfile.open(pi_uxarray_download_mesh, "r") as tar:
-        tar.extractall(data_dir)
-
-    return data_dir / "pi"
+    # Extract to shared location
+    data_dir = extract_tarfile(pi_uxarray_download_mesh, subfolder="pi")
+    return data_dir

--- a/tests/fixtures/example_data/shared_cache.py
+++ b/tests/fixtures/example_data/shared_cache.py
@@ -1,0 +1,97 @@
+"""Shared cache implementation for example data."""
+
+import os
+import tarfile
+from pathlib import Path
+
+import requests
+
+
+def get_shared_cache_dir():
+    """
+    Get the shared cache directory for all test sessions.
+
+    This creates a persistent cache directory that can be shared across
+    all test sessions, avoiding redundant downloads.
+
+    Returns:
+        Path: Path to the shared cache directory
+    """
+    # Use a persistent location that doesn't change between test sessions
+    # First try to use a directory in the user's home
+    home_cache = Path.home() / ".cache" / "pymor-test-data"
+
+    # If we can't write to home directory, fall back to /tmp/pymor-test-data
+    if os.access(Path.home(), os.W_OK):
+        cache_dir = home_cache
+    else:
+        cache_dir = Path("/tmp/pymor-test-data")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def download_file(url, filename, cache_dir=None):
+    """
+    Download a file if it doesn't exist in the cache.
+
+    Args:
+        url (str): URL to download the file from
+        filename (str): Name to save the file as
+        cache_dir (Path, optional): Directory to save the file in.
+                                   Defaults to shared cache dir.
+
+    Returns:
+        Path: Path to the downloaded file
+    """
+    if cache_dir is None:
+        cache_dir = get_shared_cache_dir()
+
+    file_path = cache_dir / filename
+
+    if not file_path.exists():
+        print(f"Downloading {url} to {file_path}...")
+        response = requests.get(url)
+        response.raise_for_status()
+        with open(file_path, "wb") as f:
+            f.write(response.content)
+        print(f"Data downloaded: {file_path}.")
+    else:
+        print(f"Using shared cached data: {file_path}.")
+
+    return file_path
+
+
+def extract_tarfile(tar_path, extract_dir=None, subfolder=None):
+    """
+    Extract a tarfile to a directory if it doesn't exist.
+
+    Args:
+        tar_path (Path): Path to the tarfile
+        extract_dir (Path, optional): Directory to extract to.
+                                     Defaults to parent of tar_path.
+        subfolder (str, optional): Subfolder within the tarfile to return.
+                                  Defaults to None.
+
+    Returns:
+        Path: Path to the extracted directory
+    """
+    if extract_dir is None:
+        extract_dir = tar_path.parent
+
+    # Determine the extraction target directory
+    if subfolder:
+        target_dir = extract_dir / subfolder
+    else:
+        # Use the tar filename without extension as the target directory
+        target_dir = extract_dir / tar_path.stem
+
+    if not target_dir.exists():
+        print(f"Extracting {tar_path} to {target_dir}...")
+        with tarfile.open(tar_path, "r") as tar:
+            tar.extractall(extract_dir)
+        print(f"Data extracted to: {target_dir}.")
+    else:
+        print(f"Using shared extracted data: {target_dir}.")
+
+    return target_dir


### PR DESCRIPTION
At the moment, each test session downloads the remote testing data separately, for each one. This is a lot of network overhead that can be saved, thus increasing the speed of our tests. I'd like to implement a better caching mechanism for the test file downloads.

WIP...