### PR TITLE
adding StopIteration error reason (no input files)

### DIFF
--- a/src/pycmor/core/rule.py
+++ b/src/pycmor/core/rule.py
@@ -269,9 +269,7 @@ class Rule:
         try:
             afile = next(f for file_collection in self.inputs for f in file_collection.files)
             afile = pathlib.Path(afile)
-            dir_timestamp = datetime.datetime.fromtimestamp(
-                afile.parent.stat().st_ctime
-            )
+            dir_timestamp = datetime.datetime.fromtimestamp(afile.parent.stat().st_ctime)
         except StopIteration:
             raise FileNotFoundError("No input files found to determine timestamp of directory!")
         except FileNotFoundError:


### PR DESCRIPTION
When no input files are found a Stop Iteration error is raised, but there is no error message to explain the reason for the crash, so maybe it is useful to have one ;) 