### PR TITLE
dataset accessors

### DIFF
--- a/doc/accessors.rst
+++ b/doc/accessors.rst
@@ -1,0 +1,347 @@
+Unified Pymor Xarray Accessors
+===============================
+
+The pymor package provides unified xarray accessors that offer a consistent interface
+to all pymor functionality through the ``data.pymor`` and ``dataset.pymor`` namespaces.
+This unified approach simplifies the user experience while maintaining full backward
+compatibility with specialized accessors.
+
+Overview
+--------
+
+Pymor registers two main types of xarray accessors:
+
+- **Specialized Accessors**: Domain-specific functionality (e.g., ``data.timefreq`` for time frequency operations)
+- **Unified Accessor**: Single namespace ``data.pymor`` that provides access to all pymor functionality
+
+The unified accessor delegates to specialized accessors while providing a consistent,
+discoverable interface for users.
+
+Features
+--------
+
+- 🎯 **Single Namespace**: All pymor functionality accessible via ``data.pymor`` and ``dataset.pymor``
+- 🔄 **Delegation Pattern**: Unified accessor delegates to specialized accessors for actual implementation
+- 🔙 **Backward Compatibility**: Existing specialized accessors (``data.timefreq``) continue to work
+- 🚀 **Future-Ready**: Easy to extend with new pymor functionality
+- 📚 **Consistent API**: Same method signatures and behavior across all access patterns
+
+Quick Start
+-----------
+
+**Basic Usage:**
+
+.. code-block:: python
+
+   import pymor  # Registers all accessors
+   import xarray as xr
+   import cftime
+
+   # Create sample data
+   times = [cftime.Datetime360Day(2000, m, 15) for m in range(1, 13)]
+   data = xr.DataArray(
+       range(12), 
+       coords={"time": times}, 
+       dims="time",
+       name="temperature"
+   )
+
+   # Use unified pymor accessor
+   freq_info = data.pymor.infer_frequency()
+   print(f"Frequency: {freq_info['frequency']}")  # 'M'
+
+   # Check temporal resolution
+   resolution = data.pymor.check_resolution(target_approx_interval=30.0)
+   print(f"Valid for resampling: {resolution['is_valid_for_resampling']}")
+
+   # Safe resampling with validation
+   resampled = data.pymor.resample_safe(
+       target_approx_interval=30.0,
+       calendar="360_day"
+   )
+
+**Dataset Usage:**
+
+.. code-block:: python
+
+   # Create dataset
+   dataset = xr.Dataset({
+       "temperature": data,
+       "precipitation": data * 2
+   })
+
+   # Use unified accessor on datasets
+   freq_info = dataset.pymor.infer_frequency()
+   
+   # Resample entire dataset
+   resampled_ds = dataset.pymor.resample_safe(
+       freq_str="3M",  # Quarterly
+       calendar="360_day"
+   )
+
+Accessor Comparison
+-------------------
+
+The unified accessor provides the same functionality as specialized accessors
+but through a consistent namespace:
+
+**Specialized Accessor (still available):**
+
+.. code-block:: python
+
+   # Time frequency operations via specialized accessor
+   data.timefreq.infer_frequency()
+   data.timefreq.check_resolution(target_approx_interval=30.0)
+   data.timefreq.resample_safe(freq_str="M")
+
+**Unified Accessor (recommended):**
+
+.. code-block:: python
+
+   # Same operations via unified accessor
+   data.pymor.infer_frequency()
+   data.pymor.check_resolution(target_approx_interval=30.0)
+   data.pymor.resample_safe(freq_str="M")
+
+Both approaches produce identical results, but the unified accessor provides
+a single, discoverable entry point for all pymor functionality.
+
+Available Methods
+-----------------
+
+The unified pymor accessor currently provides the following methods:
+
+Time Frequency Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All time frequency methods are available through the unified accessor:
+
+.. code-block:: python
+
+   # Infer temporal frequency from data
+   result = data.pymor.infer_frequency(
+       strict=True,
+       calendar="360_day",
+       log=True
+   )
+
+   # Check if resolution is sufficient for resampling
+   check = data.pymor.check_resolution(
+       target_approx_interval=30.0,
+       tolerance=0.01,
+       strict=False
+   )
+
+   # Safe resampling with automatic validation
+   resampled = data.pymor.resample_safe(
+       target_approx_interval=30.0,  # ~monthly
+       freq_str="M",                 # pandas frequency string
+       calendar="360_day",
+       method="mean"
+   )
+
+Parameter Flexibility
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``resample_safe`` method accepts flexible parameter combinations:
+
+.. code-block:: python
+
+   # Option 1: Provide target interval (will be converted to frequency string)
+   data.pymor.resample_safe(target_approx_interval=30.0)
+
+   # Option 2: Provide frequency string directly
+   data.pymor.resample_safe(freq_str="M")
+
+   # Option 3: Provide both (freq_str takes precedence)
+   data.pymor.resample_safe(
+       target_approx_interval=30.0,
+       freq_str="M"
+   )
+
+Dataset Operations
+~~~~~~~~~~~~~~~~~~
+
+For datasets, the unified accessor operates on the time dimension:
+
+.. code-block:: python
+
+   # Automatic time dimension detection
+   dataset.pymor.infer_frequency()
+
+   # Explicit time dimension specification
+   dataset.pymor.check_resolution(
+       target_approx_interval=1.0,
+       time_dim="time"
+   )
+
+   # Resample all variables in the dataset
+   resampled_ds = dataset.pymor.resample_safe(
+       freq_str="D",
+       time_dim="time"
+   )
+
+Error Handling
+--------------
+
+The unified accessor provides consistent error handling:
+
+.. code-block:: python
+
+   # Data without time dimension
+   spatial_data = xr.DataArray([[1, 2], [3, 4]], dims=["x", "y"])
+
+   try:
+       spatial_data.pymor.infer_frequency()
+   except (ValueError, KeyError) as e:
+       print(f"Error: {e}")  # No time dimension found
+
+   # Dataset with missing time dimension
+   try:
+       dataset_no_time.pymor.resample_safe(freq_str="M")
+   except ValueError as e:
+       print(f"Error: {e}")  # Time dimension not found
+
+Architecture
+------------
+
+The unified accessor uses a delegation pattern for clean separation of concerns:
+
+**Implementation Structure:**
+
+.. code-block:: python
+
+   @register_dataarray_accessor("pymor")
+   class PymorDataArrayAccessor:
+       def __init__(self, xarray_obj):
+           self._obj = xarray_obj
+           # Initialize specialized accessors
+           self._timefreq = TimeFrequencyAccessor(xarray_obj)
+       
+       def resample_safe(self, *args, **kwargs):
+           # Delegate to specialized accessor
+           return self._timefreq.resample_safe(*args, **kwargs)
+
+**Benefits:**
+
+- **Modularity**: Core functionality remains in specialized modules
+- **Maintainability**: Changes to specialized accessors automatically propagate
+- **Extensibility**: Easy to add new specialized accessors to the unified interface
+- **Testing**: Can test delegation and specialized functionality independently
+
+Future Extensions
+-----------------
+
+The unified accessor is designed to accommodate future pymor functionality:
+
+.. code-block:: python
+
+   # Future pymor features will be accessible via the unified accessor
+   # data.pymor.quality_control()      # Future QC functionality
+   # data.pymor.metadata_validation()  # Future metadata tools
+   # data.pymor.cmip_compliance()      # Future CMIP validation
+
+   # While maintaining access to specialized functionality
+   # data.pymor.timefreq.resample_safe()  # Direct access if needed
+
+Registration and Import
+-----------------------
+
+Accessors are automatically registered when importing pymor:
+
+.. code-block:: python
+
+   import pymor  # Registers all accessors
+
+   # Both specialized and unified accessors are now available
+   assert hasattr(data, 'timefreq')  # Specialized accessor
+   assert hasattr(data, 'pymor')     # Unified accessor
+
+**Internal Registration:**
+
+The accessor registration is centralized in ``pymor.accessors`` module:
+
+.. code-block:: python
+
+   # In pymor/accessors.py
+   from xarray import register_dataarray_accessor, register_dataset_accessor
+   from .core.infer_freq import TimeFrequencyAccessor, DatasetFrequencyAccessor
+
+   @register_dataarray_accessor("pymor")
+   class PymorDataArrayAccessor:
+       # Unified accessor implementation
+       pass
+
+Best Practices
+--------------
+
+**Recommended Usage:**
+
+1. **Use the unified accessor** (``data.pymor``) for new code
+2. **Maintain existing code** using specialized accessors (``data.timefreq``)
+3. **Import pymor once** at the top of your script to register all accessors
+4. **Use consistent parameter names** across different methods
+
+**Example Workflow:**
+
+.. code-block:: python
+
+   import pymor
+   import xarray as xr
+
+   def process_climate_data(dataset):
+       """Process climate dataset with unified pymor accessor."""
+       
+       # Check temporal resolution
+       resolution = dataset.pymor.check_resolution(
+           target_approx_interval=30.0  # Monthly
+       )
+       
+       if not resolution['is_valid_for_resampling']:
+           raise ValueError("Data resolution too coarse for monthly analysis")
+       
+       # Resample to monthly means
+       monthly_data = dataset.pymor.resample_safe(
+           freq_str="M",
+           method="mean"
+       )
+       
+       return monthly_data
+
+API Reference
+-------------
+
+For detailed API documentation of individual methods, see:
+
+- :doc:`infer_freq` - Core time frequency functionality
+- :doc:`API` - Complete API reference
+
+The unified accessor methods have identical signatures and behavior to their
+specialized counterparts, ensuring consistent behavior across access patterns.
+
+Migration Guide
+---------------
+
+**From Specialized to Unified Accessor:**
+
+.. code-block:: python
+
+   # Old approach (still works)
+   freq = data.timefreq.infer_frequency()
+   check = data.timefreq.check_resolution(target_approx_interval=30.0)
+   result = data.timefreq.resample_safe(freq_str="M")
+
+   # New unified approach (recommended)
+   freq = data.pymor.infer_frequency()
+   check = data.pymor.check_resolution(target_approx_interval=30.0)
+   result = data.pymor.resample_safe(freq_str="M")
+
+**No Breaking Changes:**
+
+- All existing code continues to work unchanged
+- Specialized accessors remain available
+- Method signatures and behavior are identical
+- Only the namespace changes (``timefreq`` → ``pymor``)
+
+The unified accessor provides a path forward for consistent pymor usage while
+maintaining full backward compatibility with existing code.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,6 +32,8 @@ Contents
    including_subcommand_plugins
    pycmor_fesom
    timeaveraging_frequencies
+   accessors
+   infer_freq
    cookbook
    developer_guide
    developer_setup

--- a/doc/infer_freq.rst
+++ b/doc/infer_freq.rst
@@ -187,18 +187,31 @@ Core Functions
 Accessor Methods
 ~~~~~~~~~~~~~~~~
 
-The following methods are available via xarray accessors:
+Time frequency functionality is available through xarray accessors. For comprehensive
+documentation of all accessor methods, including both specialized (``timefreq``) and 
+unified (``pymor``) accessors, see:
 
-**DataArray Accessor (``da.timefreq``):**
+.. seealso::
+   :doc:`accessors` - Complete guide to pycmor xarray accessors
+
+**Quick Reference:**
 
 .. automethod:: pycmor.core.infer_freq.TimeFrequencyAccessor.infer_frequency
 .. automethod:: pycmor.core.infer_freq.TimeFrequencyAccessor.check_resolution
 .. automethod:: pycmor.core.infer_freq.TimeFrequencyAccessor.resample_safe
 
-**Dataset Accessor (``ds.timefreq``):**
-
 .. automethod:: pycmor.core.infer_freq.DatasetFrequencyAccessor.infer_frequency
 .. automethod:: pycmor.core.infer_freq.DatasetFrequencyAccessor.resample_safe
+
+.. code-block:: python
+
+   # Specialized accessor (domain-specific)
+   result = data.timefreq.infer_frequency()
+   check = data.timefreq.check_resolution(target_approx_interval=30.0)
+
+   # Unified accessor (recommended for new code)
+   result = data.pycmor.infer_frequency()
+   check = data.pycmor.check_resolution(target_approx_interval=30.0)
 
 Calendar Support
 ----------------

--- a/doc/infer_freq.rst
+++ b/doc/infer_freq.rst
@@ -138,7 +138,7 @@ The ``status`` field in ``FrequencyResult`` indicates the quality and characteri
 .. code-block:: python
 
    import cftime
-   from toypycmor.infer_freq import infer_frequency
+   from pycmor.core.infer_freq import infer_frequency
 
    # Valid: Perfect monthly spacing
    times_valid = [

--- a/src/pycmor/__init__.py
+++ b/src/pycmor/__init__.py
@@ -2,6 +2,9 @@
 
 from . import _version
 
+# Import module that registers all xarray accessors
+from . import accessors  # noqa: F401
+
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []
 

--- a/src/pycmor/__init__.py
+++ b/src/pycmor/__init__.py
@@ -1,9 +1,10 @@
 """pycmor - Makes CMOR Simple"""
 
-from . import _version
-
 # Import module that registers all xarray accessors
 from . import accessors  # noqa: F401
+from . import (
+    _version,
+)
 
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []

--- a/src/pycmor/accessors.py
+++ b/src/pycmor/accessors.py
@@ -5,8 +5,114 @@ This module imports and registers all xarray accessors used throughout the pymor
 By importing this module, all accessors become available on xarray DataArrays and Datasets.
 """
 
-# Import modules that register xarray accessors
-from .core import infer_freq  # noqa: F401
+from xarray import register_dataarray_accessor, register_dataset_accessor
+
+# Import modules that register specialized xarray accessors
+from .core.infer_freq import DatasetFrequencyAccessor, TimeFrequencyAccessor
 
 # Future accessor imports can be added here as the project grows
 # from .other_module import other_accessor  # noqa: F401
+
+
+@register_dataarray_accessor("pymor")
+class PymorDataArrayAccessor:
+    """
+    Unified pymor accessor for xarray DataArrays.
+
+    This accessor provides access to all pymor functionality under a single namespace.
+    It delegates to specialized accessors like timefreq while providing a unified interface.
+
+    Examples
+    --------
+    # Time frequency operations
+    data.pymor.resample_safe(target_approx_interval=30.0)  # ~monthly
+    data.pymor.resample_safe(freq_str='3M')  # 3-monthly
+    data.pymor.check_resolution(target_approx_interval=1.0)  # daily
+    data.pymor.infer_frequency()  # infer frequency from data
+
+    # Future pymor functionality will also be available here
+    # data.pymor.other_feature()
+    """
+
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+        # Initialize specialized accessors
+        self._timefreq = TimeFrequencyAccessor(xarray_obj)
+
+    # Time frequency methods - delegate to TimeFrequencyAccessor
+    def resample_safe(self, *args, **kwargs):
+        """Resample data safely with temporal resolution validation.
+
+        See TimeFrequencyAccessor.resample_safe for full documentation.
+        """
+        return self._timefreq.resample_safe(*args, **kwargs)
+
+    def check_resolution(self, *args, **kwargs):
+        """Check if temporal resolution is sufficient for resampling.
+
+        See TimeFrequencyAccessor.check_resolution for full documentation.
+        """
+        return self._timefreq.check_resolution(*args, **kwargs)
+
+    def infer_frequency(self, *args, **kwargs):
+        """Infer frequency from time series data.
+
+        See TimeFrequencyAccessor.infer_frequency for full documentation.
+        """
+        return self._timefreq.infer_frequency(*args, **kwargs)
+
+    # Future pymor methods can be added here
+    # def other_feature(self, *args, **kwargs):
+    #     return self._other_accessor.other_feature(*args, **kwargs)
+
+
+@register_dataset_accessor("pymor")
+class PymorDatasetAccessor:
+    """
+    Unified pymor accessor for xarray Datasets.
+
+    This accessor provides access to all pymor functionality under a single namespace.
+    It delegates to specialized accessors like timefreq while providing a unified interface.
+
+    Examples
+    --------
+    # Time frequency operations
+    dataset.pymor.resample_safe(target_approx_interval=30.0)  # ~monthly
+    dataset.pymor.resample_safe(freq_str='3M')  # 3-monthly
+    dataset.pymor.check_resolution(target_approx_interval=1.0)  # daily
+    dataset.pymor.infer_frequency()  # infer frequency from data
+
+    # Future pymor functionality will also be available here
+    # dataset.pymor.other_feature()
+    """
+
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+        # Initialize specialized accessors
+        self._timefreq = DatasetFrequencyAccessor(xarray_obj)
+
+    # Time frequency methods - delegate to DatasetFrequencyAccessor
+    def resample_safe(self, *args, **kwargs):
+        """Resample dataset safely with temporal resolution validation.
+
+        See DatasetFrequencyAccessor.resample_safe for full documentation.
+        """
+        return self._timefreq.resample_safe(*args, **kwargs)
+
+    def check_resolution(self, *args, **kwargs):
+        """Check if temporal resolution is sufficient for resampling.
+
+        See DatasetFrequencyAccessor.check_resolution for full documentation.
+        """
+        return self._timefreq.check_resolution(*args, **kwargs)
+
+    def infer_frequency(self, *args, **kwargs):
+        """Infer frequency from time series data.
+
+        See DatasetFrequencyAccessor.infer_frequency for full documentation.
+        """
+        return self._timefreq.infer_frequency(*args, **kwargs)
+
+    # Future pymor methods can be added here
+    # def other_feature(self, *args, **kwargs):
+    #     return self._other_accessor.other_feature(*args, **kwargs)

--- a/src/pycmor/accessors.py
+++ b/src/pycmor/accessors.py
@@ -1,0 +1,12 @@
+"""
+Xarray accessor registration module for pymor.
+
+This module imports and registers all xarray accessors used throughout the pymor project.
+By importing this module, all accessors become available on xarray DataArrays and Datasets.
+"""
+
+# Import modules that register xarray accessors
+from .core import infer_freq  # noqa: F401
+
+# Future accessor imports can be added here as the project grows
+# from .other_module import other_accessor  # noqa: F401

--- a/src/pycmor/accessors.py
+++ b/src/pycmor/accessors.py
@@ -1,7 +1,7 @@
 """
-Xarray accessor registration module for pymor.
+Xarray accessor registration module for pycmor.
 
-This module imports and registers all xarray accessors used throughout the pymor project.
+This module imports and registers all xarray accessors used throughout the pycmor project.
 By importing this module, all accessors become available on xarray DataArrays and Datasets.
 """
 
@@ -14,24 +14,24 @@ from .core.infer_freq import DatasetFrequencyAccessor, TimeFrequencyAccessor
 # from .other_module import other_accessor  # noqa: F401
 
 
-@register_dataarray_accessor("pymor")
-class PymorDataArrayAccessor:
+@register_dataarray_accessor("pycmor")
+class PycmorDataArrayAccessor:
     """
-    Unified pymor accessor for xarray DataArrays.
+    Unified pycmor accessor for xarray DataArrays.
 
-    This accessor provides access to all pymor functionality under a single namespace.
+    This accessor provides access to all pycmor functionality under a single namespace.
     It delegates to specialized accessors like timefreq while providing a unified interface.
 
     Examples
     --------
     # Time frequency operations
-    data.pymor.resample_safe(target_approx_interval=30.0)  # ~monthly
-    data.pymor.resample_safe(freq_str='3M')  # 3-monthly
-    data.pymor.check_resolution(target_approx_interval=1.0)  # daily
-    data.pymor.infer_frequency()  # infer frequency from data
+    data.pycmor.resample_safe(target_approx_interval=30.0)  # ~monthly
+    data.pycmor.resample_safe(freq_str='3M')  # 3-monthly
+    data.pycmor.check_resolution(target_approx_interval=1.0)  # daily
+    data.pycmor.infer_frequency()  # infer frequency from data
 
-    # Future pymor functionality will also be available here
-    # data.pymor.other_feature()
+    # Future pycmor functionality will also be available here
+    # data.pycmor.other_feature()
     """
 
     def __init__(self, xarray_obj):
@@ -61,29 +61,29 @@ class PymorDataArrayAccessor:
         """
         return self._timefreq.infer_frequency(*args, **kwargs)
 
-    # Future pymor methods can be added here
+    # Future pycmor methods can be added here
     # def other_feature(self, *args, **kwargs):
     #     return self._other_accessor.other_feature(*args, **kwargs)
 
 
-@register_dataset_accessor("pymor")
-class PymorDatasetAccessor:
+@register_dataset_accessor("pycmor")
+class PycmorDatasetAccessor:
     """
-    Unified pymor accessor for xarray Datasets.
+    Unified pycmor accessor for xarray Datasets.
 
-    This accessor provides access to all pymor functionality under a single namespace.
+    This accessor provides access to all pycmor functionality under a single namespace.
     It delegates to specialized accessors like timefreq while providing a unified interface.
 
     Examples
     --------
     # Time frequency operations
-    dataset.pymor.resample_safe(target_approx_interval=30.0)  # ~monthly
-    dataset.pymor.resample_safe(freq_str='3M')  # 3-monthly
-    dataset.pymor.check_resolution(target_approx_interval=1.0)  # daily
-    dataset.pymor.infer_frequency()  # infer frequency from data
+    dataset.pycmor.resample_safe(target_approx_interval=30.0)  # ~monthly
+    dataset.pycmor.resample_safe(freq_str='3M')  # 3-monthly
+    dataset.pycmor.check_resolution(target_approx_interval=1.0)  # daily
+    dataset.pycmor.infer_frequency()  # infer frequency from data
 
-    # Future pymor functionality will also be available here
-    # dataset.pymor.other_feature()
+    # Future pycmor functionality will also be available here
+    # dataset.pycmor.other_feature()
     """
 
     def __init__(self, xarray_obj):
@@ -113,6 +113,6 @@ class PymorDatasetAccessor:
         """
         return self._timefreq.infer_frequency(*args, **kwargs)
 
-    # Future pymor methods can be added here
+    # Future pycmor methods can be added here
     # def other_feature(self, *args, **kwargs):
     #     return self._other_accessor.other_feature(*args, **kwargs)

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -65,8 +65,8 @@ class TestPymorDataArrayAccessor:
 
         # Results should be identical
         assert pymor_result == timefreq_result
-        assert pymor_result["frequency"] == "M"
-        assert pymor_result["status"] == "valid"
+        assert pymor_result.frequency == "M"
+        assert pymor_result.status == "valid"
 
     def test_pymor_check_resolution_delegation(self, sample_dataarray):
         """Test that pymor.check_resolution delegates correctly to timefreq."""
@@ -182,8 +182,8 @@ class TestPymorDatasetAccessor:
 
         # Results should be identical
         assert pymor_result == timefreq_result
-        assert pymor_result["frequency"] == "M"
-        assert pymor_result["status"] == "valid"
+        assert pymor_result.frequency == "M"
+        assert pymor_result.status == "valid"
 
     def test_pymor_check_resolution_delegation(self, sample_dataset):
         """Test that dataset pymor.check_resolution delegates correctly."""

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -1,0 +1,355 @@
+"""
+Tests for the unified pymor accessor functionality in accessors.py.
+
+This module tests the PymorDataArrayAccessor and PymorDatasetAccessor classes
+that provide unified access to all pymor functionality under the data.pymor
+and dataset.pymor namespaces.
+"""
+
+import cftime
+import pytest
+import xarray as xr
+
+# Import pymor to register all accessors
+import pymor  # noqa: F401
+
+
+@pytest.fixture
+def regular_monthly_time():
+    """Regular monthly time series for testing."""
+    return [cftime.Datetime360Day(2000, m, 15) for m in range(1, 5)]
+
+
+@pytest.fixture
+def sample_dataarray(regular_monthly_time):
+    """Sample DataArray with time dimension for testing."""
+    return xr.DataArray(
+        [1, 2, 3, 4],
+        coords={"time": regular_monthly_time},
+        dims="time",
+        name="temperature",
+    )
+
+
+@pytest.fixture
+def sample_dataset(sample_dataarray):
+    """Sample Dataset with time dimension for testing."""
+    return xr.Dataset({"tas": sample_dataarray, "pr": sample_dataarray * 2})
+
+
+class TestPymorDataArrayAccessor:
+    """Test the unified pymor accessor for DataArrays."""
+
+    def test_pymor_accessor_registration(self, sample_dataarray):
+        """Test that the pymor accessor is properly registered."""
+        assert hasattr(sample_dataarray, "pymor")
+        assert hasattr(
+            sample_dataarray, "timefreq"
+        )  # Specialized accessor still available
+
+    def test_pymor_accessor_methods_available(self, sample_dataarray):
+        """Test that all expected methods are available on the pymor accessor."""
+        expected_methods = ["resample_safe", "check_resolution", "infer_frequency"]
+
+        for method in expected_methods:
+            assert hasattr(sample_dataarray.pymor, method)
+            assert callable(getattr(sample_dataarray.pymor, method))
+
+    def test_pymor_infer_frequency_delegation(self, sample_dataarray):
+        """Test that pymor.infer_frequency delegates correctly to timefreq."""
+        # Test via pymor accessor
+        pymor_result = sample_dataarray.pymor.infer_frequency(log=False)
+
+        # Test via specialized accessor
+        timefreq_result = sample_dataarray.timefreq.infer_frequency(log=False)
+
+        # Results should be identical
+        assert pymor_result == timefreq_result
+        assert pymor_result["frequency"] == "M"
+        assert pymor_result["status"] == "valid"
+
+    def test_pymor_check_resolution_delegation(self, sample_dataarray):
+        """Test that pymor.check_resolution delegates correctly to timefreq."""
+        target_interval = 30.0
+
+        # Test via pymor accessor
+        pymor_result = sample_dataarray.pymor.check_resolution(
+            target_approx_interval=target_interval, calendar="360_day", log=False
+        )
+
+        # Test via specialized accessor
+        timefreq_result = sample_dataarray.timefreq.check_resolution(
+            target_approx_interval=target_interval, calendar="360_day", log=False
+        )
+
+        # Results should be identical
+        assert pymor_result == timefreq_result
+        assert "is_valid_for_resampling" in pymor_result
+        assert "comparison_status" in pymor_result
+
+    def test_pymor_resample_safe_delegation(self, sample_dataarray):
+        """Test that pymor.resample_safe delegates correctly to timefreq."""
+        # Test via pymor accessor
+        pymor_result = sample_dataarray.pymor.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Test via specialized accessor
+        timefreq_result = sample_dataarray.timefreq.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Results should be equivalent DataArrays
+        assert isinstance(pymor_result, xr.DataArray)
+        assert isinstance(timefreq_result, xr.DataArray)
+        assert pymor_result.dims == timefreq_result.dims
+        assert pymor_result.name == timefreq_result.name
+
+    def test_pymor_resample_safe_with_freq_str(self, sample_dataarray):
+        """Test pymor.resample_safe with frequency string parameter."""
+        result = sample_dataarray.pymor.resample_safe(freq_str="M", calendar="360_day")
+
+        assert isinstance(result, xr.DataArray)
+        assert "time" in result.dims
+        assert result.name == sample_dataarray.name
+
+    def test_pymor_resample_safe_parameter_flexibility(self, sample_dataarray):
+        """Test that pymor.resample_safe accepts flexible parameter combinations."""
+        # Test with target_approx_interval only
+        result1 = sample_dataarray.pymor.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Test with freq_str only
+        result2 = sample_dataarray.pymor.resample_safe(freq_str="M", calendar="360_day")
+
+        # Test with both parameters
+        result3 = sample_dataarray.pymor.resample_safe(
+            target_approx_interval=30.0, freq_str="M", calendar="360_day"
+        )
+
+        # All should produce valid results
+        for result in [result1, result2, result3]:
+            assert isinstance(result, xr.DataArray)
+            assert "time" in result.dims
+
+    def test_pymor_accessor_error_handling(self):
+        """Test that pymor accessor handles errors appropriately."""
+        # Create DataArray without time dimension
+        da_no_time = xr.DataArray([1, 2, 3], dims=["x"])
+
+        # Should raise appropriate error when trying to use time-based methods
+        with pytest.raises((ValueError, KeyError)):
+            da_no_time.pymor.infer_frequency()
+
+    def test_pymor_accessor_docstrings(self, sample_dataarray):
+        """Test that pymor accessor methods have proper docstrings."""
+        methods = ["resample_safe", "check_resolution", "infer_frequency"]
+
+        for method_name in methods:
+            method = getattr(sample_dataarray.pymor, method_name)
+            assert method.__doc__ is not None
+            assert len(method.__doc__.strip()) > 0
+            # Should reference the specialized accessor documentation
+            assert "TimeFrequencyAccessor" in method.__doc__
+
+
+class TestPymorDatasetAccessor:
+    """Test the unified pymor accessor for Datasets."""
+
+    def test_pymor_accessor_registration(self, sample_dataset):
+        """Test that the pymor accessor is properly registered for datasets."""
+        assert hasattr(sample_dataset, "pymor")
+        assert hasattr(
+            sample_dataset, "timefreq"
+        )  # Specialized accessor still available
+
+    def test_pymor_accessor_methods_available(self, sample_dataset):
+        """Test that all expected methods are available on the dataset pymor accessor."""
+        expected_methods = ["resample_safe", "check_resolution", "infer_frequency"]
+
+        for method in expected_methods:
+            assert hasattr(sample_dataset.pymor, method)
+            assert callable(getattr(sample_dataset.pymor, method))
+
+    def test_pymor_infer_frequency_delegation(self, sample_dataset):
+        """Test that dataset pymor.infer_frequency delegates correctly."""
+        # Test via pymor accessor
+        pymor_result = sample_dataset.pymor.infer_frequency(log=False)
+
+        # Test via specialized accessor
+        timefreq_result = sample_dataset.timefreq.infer_frequency(log=False)
+
+        # Results should be identical
+        assert pymor_result == timefreq_result
+        assert pymor_result["frequency"] == "M"
+        assert pymor_result["status"] == "valid"
+
+    def test_pymor_check_resolution_delegation(self, sample_dataset):
+        """Test that dataset pymor.check_resolution delegates correctly."""
+        target_interval = 30.0
+
+        # Test via pymor accessor
+        pymor_result = sample_dataset.pymor.check_resolution(
+            target_approx_interval=target_interval, calendar="360_day", log=False
+        )
+
+        # Test via specialized accessor
+        timefreq_result = sample_dataset.timefreq.check_resolution(
+            target_approx_interval=target_interval, calendar="360_day", log=False
+        )
+
+        # Results should be identical
+        assert pymor_result == timefreq_result
+        assert "is_valid_for_resampling" in pymor_result
+
+    def test_pymor_resample_safe_delegation(self, sample_dataset):
+        """Test that dataset pymor.resample_safe delegates correctly."""
+        # Test via pymor accessor
+        pymor_result = sample_dataset.pymor.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Test via specialized accessor
+        timefreq_result = sample_dataset.timefreq.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Results should be equivalent Datasets
+        assert isinstance(pymor_result, xr.Dataset)
+        assert isinstance(timefreq_result, xr.Dataset)
+        assert set(pymor_result.data_vars) == set(timefreq_result.data_vars)
+        assert pymor_result.dims == timefreq_result.dims
+
+    def test_pymor_resample_safe_preserves_variables(self, sample_dataset):
+        """Test that dataset pymor.resample_safe preserves all data variables."""
+        result = sample_dataset.pymor.resample_safe(freq_str="M", calendar="360_day")
+
+        assert isinstance(result, xr.Dataset)
+        assert set(result.data_vars) == set(sample_dataset.data_vars)
+        assert "tas" in result.data_vars
+        assert "pr" in result.data_vars
+
+    def test_pymor_dataset_error_handling(self):
+        """Test that dataset pymor accessor handles errors appropriately."""
+        # Create Dataset without time dimension
+        ds_no_time = xr.Dataset(
+            {
+                "var1": xr.DataArray([1, 2, 3], dims=["x"]),
+                "var2": xr.DataArray([4, 5, 6], dims=["x"]),
+            }
+        )
+
+        # Should raise appropriate error when trying to use time-based methods
+        with pytest.raises((ValueError, KeyError)):
+            ds_no_time.pymor.infer_frequency()
+
+    def test_pymor_dataset_docstrings(self, sample_dataset):
+        """Test that dataset pymor accessor methods have proper docstrings."""
+        methods = ["resample_safe", "check_resolution", "infer_frequency"]
+
+        for method_name in methods:
+            method = getattr(sample_dataset.pymor, method_name)
+            assert method.__doc__ is not None
+            assert len(method.__doc__.strip()) > 0
+            # Should reference the specialized accessor documentation
+            assert "DatasetFrequencyAccessor" in method.__doc__
+
+
+class TestAccessorInteroperability:
+    """Test interoperability between specialized and unified accessors."""
+
+    def test_both_accessors_coexist(self, sample_dataarray, sample_dataset):
+        """Test that both specialized and unified accessors work together."""
+        # DataArray
+        assert hasattr(sample_dataarray, "timefreq")
+        assert hasattr(sample_dataarray, "pymor")
+
+        # Dataset
+        assert hasattr(sample_dataset, "timefreq")
+        assert hasattr(sample_dataset, "pymor")
+
+    def test_consistent_results_across_accessors(self, sample_dataarray):
+        """Test that specialized and unified accessors give consistent results."""
+        # Test infer_frequency
+        timefreq_freq = sample_dataarray.timefreq.infer_frequency(log=False)
+        pymor_freq = sample_dataarray.pymor.infer_frequency(log=False)
+        assert timefreq_freq == pymor_freq
+
+        # Test check_resolution
+        timefreq_check = sample_dataarray.timefreq.check_resolution(
+            target_approx_interval=30.0, calendar="360_day", log=False
+        )
+        pymor_check = sample_dataarray.pymor.check_resolution(
+            target_approx_interval=30.0, calendar="360_day", log=False
+        )
+        assert timefreq_check == pymor_check
+
+    def test_unified_accessor_initialization(self, sample_dataarray, sample_dataset):
+        """Test that unified accessors initialize their internal specialized accessors."""
+        # Check that internal _timefreq accessor is properly initialized
+        da_pymor = sample_dataarray.pymor
+        assert hasattr(da_pymor, "_timefreq")
+        assert da_pymor._timefreq is not None
+
+        ds_pymor = sample_dataset.pymor
+        assert hasattr(ds_pymor, "_timefreq")
+        assert ds_pymor._timefreq is not None
+
+    def test_accessor_independence(self, sample_dataarray):
+        """Test that accessors operate independently without interference."""
+        # Modify data through one accessor
+        result1 = sample_dataarray.timefreq.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Use the other accessor - should not be affected
+        result2 = sample_dataarray.pymor.resample_safe(
+            target_approx_interval=30.0, calendar="360_day"
+        )
+
+        # Original data should be unchanged
+        assert len(sample_dataarray) == 4
+
+        # Results should be equivalent
+        assert isinstance(result1, xr.DataArray)
+        assert isinstance(result2, xr.DataArray)
+
+
+class TestAccessorRegistration:
+    """Test that accessors are properly registered through the accessors.py module."""
+
+    def test_import_registers_accessors(self):
+        """Test that importing pymor registers all accessors."""
+        # Create test data
+        times = [cftime.Datetime360Day(2000, m, 15) for m in range(1, 4)]
+        da = xr.DataArray([1, 2, 3], coords={"time": times}, dims="time")
+        ds = xr.Dataset({"var": da})
+
+        # Both specialized and unified accessors should be available
+        assert hasattr(da, "timefreq")
+        assert hasattr(da, "pymor")
+        assert hasattr(ds, "timefreq")
+        assert hasattr(ds, "pymor")
+
+    def test_accessor_namespace_separation(self, sample_dataarray):
+        """Test that accessor namespaces are properly separated."""
+        # timefreq and pymor should be different objects
+        assert sample_dataarray.timefreq is not sample_dataarray.pymor
+
+        # But pymor should delegate to timefreq functionality
+        assert hasattr(sample_dataarray.pymor, "_timefreq")
+
+    def test_future_extensibility(self, sample_dataarray):
+        """Test that the unified accessor is designed for future extensibility."""
+        # The unified accessor should have a clear structure for adding new features
+        pymor_accessor = sample_dataarray.pymor
+
+        # Should have the current timefreq methods
+        assert hasattr(pymor_accessor, "resample_safe")
+        assert hasattr(pymor_accessor, "check_resolution")
+        assert hasattr(pymor_accessor, "infer_frequency")
+
+        # Should have internal structure that supports adding more specialized accessors
+        assert hasattr(pymor_accessor, "_timefreq")
+        # Future: assert hasattr(pymor_accessor, '_other_accessor')

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -10,7 +10,7 @@ import cftime
 import pytest
 import xarray as xr
 
-# Import pymor to register all accessors
+# Import pycmor to register all accessors
 import pycmor  # noqa: F401
 
 
@@ -42,7 +42,7 @@ class TestPycmorDataArrayAccessor:
 
     def test_pycmor_accessor_registration(self, sample_dataarray):
         """Test that the pycmor accessor is properly registered."""
-        assert hasattr(sample_dataarray, "pymor")
+        assert hasattr(sample_dataarray, "pycmor")
         assert hasattr(sample_dataarray, "timefreq")  # Specialized accessor still available
 
     def test_pycmor_accessor_methods_available(self, sample_dataarray):
@@ -54,7 +54,7 @@ class TestPycmorDataArrayAccessor:
             assert callable(getattr(sample_dataarray.pycmor, method))
 
     def test_pycmor_infer_frequency_delegation(self, sample_dataarray):
-        """Test that pymor.infer_frequency delegates correctly to timefreq."""
+        """Test that pycmor.infer_frequency delegates correctly to timefreq."""
         # Test via pycmor accessor
         pycmor_result = sample_dataarray.pycmor.infer_frequency(log=False)
 
@@ -67,7 +67,7 @@ class TestPycmorDataArrayAccessor:
         assert pycmor_result.status == "valid"
 
     def test_pycmor_check_resolution_delegation(self, sample_dataarray):
-        """Test that pymor.check_resolution delegates correctly to timefreq."""
+        """Test that pycmor.check_resolution delegates correctly to timefreq."""
         target_interval = 30.0
 
         # Test via pycmor accessor
@@ -86,7 +86,7 @@ class TestPycmorDataArrayAccessor:
         assert "comparison_status" in pycmor_result
 
     def test_pycmor_resample_safe_delegation(self, sample_dataarray):
-        """Test that pymor.resample_safe delegates correctly to timefreq."""
+        """Test that pycmor.resample_safe delegates correctly to timefreq."""
         # Test via pycmor accessor
         pycmor_result = sample_dataarray.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
@@ -100,7 +100,7 @@ class TestPycmorDataArrayAccessor:
         assert pycmor_result.name == timefreq_result.name
 
     def test_pycmor_resample_safe_with_freq_str(self, sample_dataarray):
-        """Test pymor.resample_safe with frequency string parameter."""
+        """Test pycmor.resample_safe with frequency string parameter."""
         result = sample_dataarray.pycmor.resample_safe(freq_str="M", calendar="360_day")
 
         assert isinstance(result, xr.DataArray)
@@ -108,7 +108,7 @@ class TestPycmorDataArrayAccessor:
         assert result.name == sample_dataarray.name
 
     def test_pycmor_resample_safe_parameter_flexibility(self, sample_dataarray):
-        """Test that pymor.resample_safe accepts flexible parameter combinations."""
+        """Test that pycmor.resample_safe accepts flexible parameter combinations."""
         # Test with target_approx_interval only
         result1 = sample_dataarray.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
@@ -149,7 +149,7 @@ class TestPycmorDatasetAccessor:
 
     def test_pycmor_accessor_registration(self, sample_dataset):
         """Test that the pycmor accessor is properly registered for datasets."""
-        assert hasattr(sample_dataset, "pymor")
+        assert hasattr(sample_dataset, "pycmor")
         assert hasattr(sample_dataset, "timefreq")  # Specialized accessor still available
 
     def test_pycmor_accessor_methods_available(self, sample_dataset):
@@ -161,7 +161,7 @@ class TestPycmorDatasetAccessor:
             assert callable(getattr(sample_dataset.pycmor, method))
 
     def test_pycmor_infer_frequency_delegation(self, sample_dataset):
-        """Test that dataset pymor.infer_frequency delegates correctly."""
+        """Test that dataset pycmor.infer_frequency delegates correctly."""
         # Test via pycmor accessor
         pycmor_result = sample_dataset.pycmor.infer_frequency(log=False)
 
@@ -174,7 +174,7 @@ class TestPycmorDatasetAccessor:
         assert pycmor_result.status == "valid"
 
     def test_pycmor_check_resolution_delegation(self, sample_dataset):
-        """Test that dataset pymor.check_resolution delegates correctly."""
+        """Test that dataset pycmor.check_resolution delegates correctly."""
         target_interval = 30.0
 
         # Test via pycmor accessor
@@ -192,7 +192,7 @@ class TestPycmorDatasetAccessor:
         assert "is_valid_for_resampling" in pycmor_result
 
     def test_pycmor_resample_safe_delegation(self, sample_dataset):
-        """Test that dataset pymor.resample_safe delegates correctly."""
+        """Test that dataset pycmor.resample_safe delegates correctly."""
         # Test via pycmor accessor
         pycmor_result = sample_dataset.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
@@ -206,7 +206,7 @@ class TestPycmorDatasetAccessor:
         assert pycmor_result.dims == timefreq_result.dims
 
     def test_pycmor_resample_safe_preserves_variables(self, sample_dataset):
-        """Test that dataset pymor.resample_safe preserves all data variables."""
+        """Test that dataset pycmor.resample_safe preserves all data variables."""
         result = sample_dataset.pycmor.resample_safe(freq_str="M", calendar="360_day")
 
         assert isinstance(result, xr.Dataset)
@@ -247,11 +247,11 @@ class TestAccessorInteroperability:
         """Test that both specialized and unified accessors work together."""
         # DataArray
         assert hasattr(sample_dataarray, "timefreq")
-        assert hasattr(sample_dataarray, "pymor")
+        assert hasattr(sample_dataarray, "pycmor")
 
         # Dataset
         assert hasattr(sample_dataset, "timefreq")
-        assert hasattr(sample_dataset, "pymor")
+        assert hasattr(sample_dataset, "pycmor")
 
     def test_consistent_results_across_accessors(self, sample_dataarray):
         """Test that specialized and unified accessors give consistent results."""
@@ -308,16 +308,16 @@ class TestAccessorRegistration:
 
         # Both specialized and unified accessors should be available
         assert hasattr(da, "timefreq")
-        assert hasattr(da, "pymor")
+        assert hasattr(da, "pycmor")
         assert hasattr(ds, "timefreq")
-        assert hasattr(ds, "pymor")
+        assert hasattr(ds, "pycmor")
 
     def test_accessor_namespace_separation(self, sample_dataarray):
         """Test that accessor namespaces are properly separated."""
-        # timefreq and pymor should be different objects
+        # timefreq and pycmor should be different objects
         assert sample_dataarray.timefreq is not sample_dataarray.pycmor
 
-        # But pymor should delegate to timefreq functionality
+        # But pycmor should delegate to timefreq functionality
         assert hasattr(sample_dataarray.pycmor, "_timefreq")
 
     def test_future_extensibility(self, sample_dataarray):

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -1,9 +1,9 @@
 """
-Tests for the unified pymor accessor functionality in accessors.py.
+Tests for the unified pycmor accessor functionality in accessors.py.
 
-This module tests the PymorDataArrayAccessor and PymorDatasetAccessor classes
-that provide unified access to all pymor functionality under the data.pymor
-and dataset.pymor namespaces.
+This module tests the PycmorDataArrayAccessor and PycmorDatasetAccessor classes
+that provide unified access to all pycmor functionality under the data.pycmor
+and dataset.pycmor namespaces.
 """
 
 import cftime
@@ -11,7 +11,7 @@ import pytest
 import xarray as xr
 
 # Import pymor to register all accessors
-import pymor  # noqa: F401
+import pycmor  # noqa: F401
 
 
 @pytest.fixture
@@ -37,43 +37,41 @@ def sample_dataset(sample_dataarray):
     return xr.Dataset({"tas": sample_dataarray, "pr": sample_dataarray * 2})
 
 
-class TestPymorDataArrayAccessor:
-    """Test the unified pymor accessor for DataArrays."""
+class TestPycmorDataArrayAccessor:
+    """Test the unified pycmor accessor for DataArrays."""
 
-    def test_pymor_accessor_registration(self, sample_dataarray):
-        """Test that the pymor accessor is properly registered."""
+    def test_pycmor_accessor_registration(self, sample_dataarray):
+        """Test that the pycmor accessor is properly registered."""
         assert hasattr(sample_dataarray, "pymor")
-        assert hasattr(
-            sample_dataarray, "timefreq"
-        )  # Specialized accessor still available
+        assert hasattr(sample_dataarray, "timefreq")  # Specialized accessor still available
 
-    def test_pymor_accessor_methods_available(self, sample_dataarray):
-        """Test that all expected methods are available on the pymor accessor."""
+    def test_pycmor_accessor_methods_available(self, sample_dataarray):
+        """Test that all expected methods are available on the pycmor accessor."""
         expected_methods = ["resample_safe", "check_resolution", "infer_frequency"]
 
         for method in expected_methods:
-            assert hasattr(sample_dataarray.pymor, method)
-            assert callable(getattr(sample_dataarray.pymor, method))
+            assert hasattr(sample_dataarray.pycmor, method)
+            assert callable(getattr(sample_dataarray.pycmor, method))
 
-    def test_pymor_infer_frequency_delegation(self, sample_dataarray):
+    def test_pycmor_infer_frequency_delegation(self, sample_dataarray):
         """Test that pymor.infer_frequency delegates correctly to timefreq."""
-        # Test via pymor accessor
-        pymor_result = sample_dataarray.pymor.infer_frequency(log=False)
+        # Test via pycmor accessor
+        pycmor_result = sample_dataarray.pycmor.infer_frequency(log=False)
 
         # Test via specialized accessor
         timefreq_result = sample_dataarray.timefreq.infer_frequency(log=False)
 
         # Results should be identical
-        assert pymor_result == timefreq_result
-        assert pymor_result.frequency == "M"
-        assert pymor_result.status == "valid"
+        assert pycmor_result == timefreq_result
+        assert pycmor_result.frequency == "M"
+        assert pycmor_result.status == "valid"
 
-    def test_pymor_check_resolution_delegation(self, sample_dataarray):
+    def test_pycmor_check_resolution_delegation(self, sample_dataarray):
         """Test that pymor.check_resolution delegates correctly to timefreq."""
         target_interval = 30.0
 
-        # Test via pymor accessor
-        pymor_result = sample_dataarray.pymor.check_resolution(
+        # Test via pycmor accessor
+        pycmor_result = sample_dataarray.pycmor.check_resolution(
             target_approx_interval=target_interval, calendar="360_day", log=False
         )
 
@@ -83,114 +81,104 @@ class TestPymorDataArrayAccessor:
         )
 
         # Results should be identical
-        assert pymor_result == timefreq_result
-        assert "is_valid_for_resampling" in pymor_result
-        assert "comparison_status" in pymor_result
+        assert pycmor_result == timefreq_result
+        assert "is_valid_for_resampling" in pycmor_result
+        assert "comparison_status" in pycmor_result
 
-    def test_pymor_resample_safe_delegation(self, sample_dataarray):
+    def test_pycmor_resample_safe_delegation(self, sample_dataarray):
         """Test that pymor.resample_safe delegates correctly to timefreq."""
-        # Test via pymor accessor
-        pymor_result = sample_dataarray.pymor.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        # Test via pycmor accessor
+        pycmor_result = sample_dataarray.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Test via specialized accessor
-        timefreq_result = sample_dataarray.timefreq.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        timefreq_result = sample_dataarray.timefreq.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Results should be equivalent DataArrays
-        assert isinstance(pymor_result, xr.DataArray)
+        assert isinstance(pycmor_result, xr.DataArray)
         assert isinstance(timefreq_result, xr.DataArray)
-        assert pymor_result.dims == timefreq_result.dims
-        assert pymor_result.name == timefreq_result.name
+        assert pycmor_result.dims == timefreq_result.dims
+        assert pycmor_result.name == timefreq_result.name
 
-    def test_pymor_resample_safe_with_freq_str(self, sample_dataarray):
+    def test_pycmor_resample_safe_with_freq_str(self, sample_dataarray):
         """Test pymor.resample_safe with frequency string parameter."""
-        result = sample_dataarray.pymor.resample_safe(freq_str="M", calendar="360_day")
+        result = sample_dataarray.pycmor.resample_safe(freq_str="M", calendar="360_day")
 
         assert isinstance(result, xr.DataArray)
         assert "time" in result.dims
         assert result.name == sample_dataarray.name
 
-    def test_pymor_resample_safe_parameter_flexibility(self, sample_dataarray):
+    def test_pycmor_resample_safe_parameter_flexibility(self, sample_dataarray):
         """Test that pymor.resample_safe accepts flexible parameter combinations."""
         # Test with target_approx_interval only
-        result1 = sample_dataarray.pymor.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        result1 = sample_dataarray.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Test with freq_str only
-        result2 = sample_dataarray.pymor.resample_safe(freq_str="M", calendar="360_day")
+        result2 = sample_dataarray.pycmor.resample_safe(freq_str="M", calendar="360_day")
 
         # Test with both parameters
-        result3 = sample_dataarray.pymor.resample_safe(
-            target_approx_interval=30.0, freq_str="M", calendar="360_day"
-        )
+        result3 = sample_dataarray.pycmor.resample_safe(target_approx_interval=30.0, freq_str="M", calendar="360_day")
 
         # All should produce valid results
         for result in [result1, result2, result3]:
             assert isinstance(result, xr.DataArray)
             assert "time" in result.dims
 
-    def test_pymor_accessor_error_handling(self):
-        """Test that pymor accessor handles errors appropriately."""
+    def test_pycmor_accessor_error_handling(self):
+        """Test that pycmor accessor handles errors appropriately."""
         # Create DataArray without time dimension
         da_no_time = xr.DataArray([1, 2, 3], dims=["x"])
 
         # Should raise appropriate error when trying to use time-based methods
         with pytest.raises((ValueError, KeyError)):
-            da_no_time.pymor.infer_frequency()
+            da_no_time.pycmor.infer_frequency()
 
-    def test_pymor_accessor_docstrings(self, sample_dataarray):
-        """Test that pymor accessor methods have proper docstrings."""
+    def test_pycmor_accessor_docstrings(self, sample_dataarray):
+        """Test that pycmor accessor methods have proper docstrings."""
         methods = ["resample_safe", "check_resolution", "infer_frequency"]
 
         for method_name in methods:
-            method = getattr(sample_dataarray.pymor, method_name)
+            method = getattr(sample_dataarray.pycmor, method_name)
             assert method.__doc__ is not None
             assert len(method.__doc__.strip()) > 0
             # Should reference the specialized accessor documentation
             assert "TimeFrequencyAccessor" in method.__doc__
 
 
-class TestPymorDatasetAccessor:
-    """Test the unified pymor accessor for Datasets."""
+class TestPycmorDatasetAccessor:
+    """Test the unified pycmor accessor for Datasets."""
 
-    def test_pymor_accessor_registration(self, sample_dataset):
-        """Test that the pymor accessor is properly registered for datasets."""
+    def test_pycmor_accessor_registration(self, sample_dataset):
+        """Test that the pycmor accessor is properly registered for datasets."""
         assert hasattr(sample_dataset, "pymor")
-        assert hasattr(
-            sample_dataset, "timefreq"
-        )  # Specialized accessor still available
+        assert hasattr(sample_dataset, "timefreq")  # Specialized accessor still available
 
-    def test_pymor_accessor_methods_available(self, sample_dataset):
-        """Test that all expected methods are available on the dataset pymor accessor."""
+    def test_pycmor_accessor_methods_available(self, sample_dataset):
+        """Test that all expected methods are available on the dataset pycmor accessor."""
         expected_methods = ["resample_safe", "check_resolution", "infer_frequency"]
 
         for method in expected_methods:
-            assert hasattr(sample_dataset.pymor, method)
-            assert callable(getattr(sample_dataset.pymor, method))
+            assert hasattr(sample_dataset.pycmor, method)
+            assert callable(getattr(sample_dataset.pycmor, method))
 
-    def test_pymor_infer_frequency_delegation(self, sample_dataset):
+    def test_pycmor_infer_frequency_delegation(self, sample_dataset):
         """Test that dataset pymor.infer_frequency delegates correctly."""
-        # Test via pymor accessor
-        pymor_result = sample_dataset.pymor.infer_frequency(log=False)
+        # Test via pycmor accessor
+        pycmor_result = sample_dataset.pycmor.infer_frequency(log=False)
 
         # Test via specialized accessor
         timefreq_result = sample_dataset.timefreq.infer_frequency(log=False)
 
         # Results should be identical
-        assert pymor_result == timefreq_result
-        assert pymor_result.frequency == "M"
-        assert pymor_result.status == "valid"
+        assert pycmor_result == timefreq_result
+        assert pycmor_result.frequency == "M"
+        assert pycmor_result.status == "valid"
 
-    def test_pymor_check_resolution_delegation(self, sample_dataset):
+    def test_pycmor_check_resolution_delegation(self, sample_dataset):
         """Test that dataset pymor.check_resolution delegates correctly."""
         target_interval = 30.0
 
-        # Test via pymor accessor
-        pymor_result = sample_dataset.pymor.check_resolution(
+        # Test via pycmor accessor
+        pycmor_result = sample_dataset.pycmor.check_resolution(
             target_approx_interval=target_interval, calendar="360_day", log=False
         )
 
@@ -200,38 +188,34 @@ class TestPymorDatasetAccessor:
         )
 
         # Results should be identical
-        assert pymor_result == timefreq_result
-        assert "is_valid_for_resampling" in pymor_result
+        assert pycmor_result == timefreq_result
+        assert "is_valid_for_resampling" in pycmor_result
 
-    def test_pymor_resample_safe_delegation(self, sample_dataset):
+    def test_pycmor_resample_safe_delegation(self, sample_dataset):
         """Test that dataset pymor.resample_safe delegates correctly."""
-        # Test via pymor accessor
-        pymor_result = sample_dataset.pymor.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        # Test via pycmor accessor
+        pycmor_result = sample_dataset.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Test via specialized accessor
-        timefreq_result = sample_dataset.timefreq.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        timefreq_result = sample_dataset.timefreq.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Results should be equivalent Datasets
-        assert isinstance(pymor_result, xr.Dataset)
+        assert isinstance(pycmor_result, xr.Dataset)
         assert isinstance(timefreq_result, xr.Dataset)
-        assert set(pymor_result.data_vars) == set(timefreq_result.data_vars)
-        assert pymor_result.dims == timefreq_result.dims
+        assert set(pycmor_result.data_vars) == set(timefreq_result.data_vars)
+        assert pycmor_result.dims == timefreq_result.dims
 
-    def test_pymor_resample_safe_preserves_variables(self, sample_dataset):
+    def test_pycmor_resample_safe_preserves_variables(self, sample_dataset):
         """Test that dataset pymor.resample_safe preserves all data variables."""
-        result = sample_dataset.pymor.resample_safe(freq_str="M", calendar="360_day")
+        result = sample_dataset.pycmor.resample_safe(freq_str="M", calendar="360_day")
 
         assert isinstance(result, xr.Dataset)
         assert set(result.data_vars) == set(sample_dataset.data_vars)
         assert "tas" in result.data_vars
         assert "pr" in result.data_vars
 
-    def test_pymor_dataset_error_handling(self):
-        """Test that dataset pymor accessor handles errors appropriately."""
+    def test_pycmor_dataset_error_handling(self):
+        """Test that dataset pycmor accessor handles errors appropriately."""
         # Create Dataset without time dimension
         ds_no_time = xr.Dataset(
             {
@@ -242,14 +226,14 @@ class TestPymorDatasetAccessor:
 
         # Should raise appropriate error when trying to use time-based methods
         with pytest.raises((ValueError, KeyError)):
-            ds_no_time.pymor.infer_frequency()
+            ds_no_time.pycmor.infer_frequency()
 
-    def test_pymor_dataset_docstrings(self, sample_dataset):
-        """Test that dataset pymor accessor methods have proper docstrings."""
+    def test_pycmor_dataset_docstrings(self, sample_dataset):
+        """Test that dataset pycmor accessor methods have proper docstrings."""
         methods = ["resample_safe", "check_resolution", "infer_frequency"]
 
         for method_name in methods:
-            method = getattr(sample_dataset.pymor, method_name)
+            method = getattr(sample_dataset.pycmor, method_name)
             assert method.__doc__ is not None
             assert len(method.__doc__.strip()) > 0
             # Should reference the specialized accessor documentation
@@ -273,40 +257,36 @@ class TestAccessorInteroperability:
         """Test that specialized and unified accessors give consistent results."""
         # Test infer_frequency
         timefreq_freq = sample_dataarray.timefreq.infer_frequency(log=False)
-        pymor_freq = sample_dataarray.pymor.infer_frequency(log=False)
-        assert timefreq_freq == pymor_freq
+        pycmor_freq = sample_dataarray.pycmor.infer_frequency(log=False)
+        assert timefreq_freq == pycmor_freq
 
         # Test check_resolution
         timefreq_check = sample_dataarray.timefreq.check_resolution(
             target_approx_interval=30.0, calendar="360_day", log=False
         )
-        pymor_check = sample_dataarray.pymor.check_resolution(
+        pycmor_check = sample_dataarray.pycmor.check_resolution(
             target_approx_interval=30.0, calendar="360_day", log=False
         )
-        assert timefreq_check == pymor_check
+        assert timefreq_check == pycmor_check
 
     def test_unified_accessor_initialization(self, sample_dataarray, sample_dataset):
         """Test that unified accessors initialize their internal specialized accessors."""
         # Check that internal _timefreq accessor is properly initialized
-        da_pymor = sample_dataarray.pymor
-        assert hasattr(da_pymor, "_timefreq")
-        assert da_pymor._timefreq is not None
+        da_pycmor = sample_dataarray.pycmor
+        assert hasattr(da_pycmor, "_timefreq")
+        assert da_pycmor._timefreq is not None
 
-        ds_pymor = sample_dataset.pymor
-        assert hasattr(ds_pymor, "_timefreq")
-        assert ds_pymor._timefreq is not None
+        ds_pycmor = sample_dataset.pycmor
+        assert hasattr(ds_pycmor, "_timefreq")
+        assert ds_pycmor._timefreq is not None
 
     def test_accessor_independence(self, sample_dataarray):
         """Test that accessors operate independently without interference."""
         # Modify data through one accessor
-        result1 = sample_dataarray.timefreq.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        result1 = sample_dataarray.timefreq.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Use the other accessor - should not be affected
-        result2 = sample_dataarray.pymor.resample_safe(
-            target_approx_interval=30.0, calendar="360_day"
-        )
+        result2 = sample_dataarray.pycmor.resample_safe(target_approx_interval=30.0, calendar="360_day")
 
         # Original data should be unchanged
         assert len(sample_dataarray) == 4
@@ -320,7 +300,7 @@ class TestAccessorRegistration:
     """Test that accessors are properly registered through the accessors.py module."""
 
     def test_import_registers_accessors(self):
-        """Test that importing pymor registers all accessors."""
+        """Test that importing pycmor registers all accessors."""
         # Create test data
         times = [cftime.Datetime360Day(2000, m, 15) for m in range(1, 4)]
         da = xr.DataArray([1, 2, 3], coords={"time": times}, dims="time")
@@ -335,21 +315,21 @@ class TestAccessorRegistration:
     def test_accessor_namespace_separation(self, sample_dataarray):
         """Test that accessor namespaces are properly separated."""
         # timefreq and pymor should be different objects
-        assert sample_dataarray.timefreq is not sample_dataarray.pymor
+        assert sample_dataarray.timefreq is not sample_dataarray.pycmor
 
         # But pymor should delegate to timefreq functionality
-        assert hasattr(sample_dataarray.pymor, "_timefreq")
+        assert hasattr(sample_dataarray.pycmor, "_timefreq")
 
     def test_future_extensibility(self, sample_dataarray):
         """Test that the unified accessor is designed for future extensibility."""
         # The unified accessor should have a clear structure for adding new features
-        pymor_accessor = sample_dataarray.pymor
+        pycmor_accessor = sample_dataarray.pycmor
 
         # Should have the current timefreq methods
-        assert hasattr(pymor_accessor, "resample_safe")
-        assert hasattr(pymor_accessor, "check_resolution")
-        assert hasattr(pymor_accessor, "infer_frequency")
+        assert hasattr(pycmor_accessor, "resample_safe")
+        assert hasattr(pycmor_accessor, "check_resolution")
+        assert hasattr(pycmor_accessor, "infer_frequency")
 
         # Should have internal structure that supports adding more specialized accessors
-        assert hasattr(pymor_accessor, "_timefreq")
-        # Future: assert hasattr(pymor_accessor, '_other_accessor')
+        assert hasattr(pycmor_accessor, "_timefreq")
+        # Future: assert hasattr(pycmor_accessor, '_other_accessor')


### PR DESCRIPTION
Rebased version of #188

This PR adds unified xarray accessors for pycmor functionality, providing a clean interface for time frequency operations.

## Summary

- Adds dedicated  module for xarray accessor registration
- Implements unified  accessor alongside specialized  accessor
- Comprehensive test suite for accessor functionality
- Updated documentation

## Changes from original PR #188

This is a clean rebase of #188 onto the latest prep-release branch, with package naming updated from `pymor` to `pycmor`.

## Related

- Original PR: #188