### PR TITLE
fix: replace pkg_resources with importlib.metadata

### DIFF
--- a/src/pycmor/cli.py
+++ b/src/pycmor/cli.py
@@ -1,9 +1,9 @@
 import os
 import sys
 from importlib import resources
+from importlib.metadata import entry_points
 from typing import List
 
-from importlib.metadata import entry_points
 import rich_click as click
 import yaml
 from click_loguru import ClickLoguru

--- a/src/pycmor/cli.py
+++ b/src/pycmor/cli.py
@@ -3,7 +3,7 @@ import sys
 from importlib import resources
 from typing import List
 
-import pkg_resources
+from importlib.metadata import entry_points
 import rich_click as click
 import yaml
 from click_loguru import ClickLoguru
@@ -69,7 +69,7 @@ def find_subcommands():
     groups = ["pycmor.cli_subcommands", "pymor.cli_subcommands"]
     discovered_subcommands = {}
     for group in groups:
-        for entry_point in pkg_resources.iter_entry_points(group):
+        for entry_point in entry_points(group=group):
             discovered_subcommands[entry_point.name] = {
                 "plugin_name": entry_point.module_name.split(".")[0],
                 "callable": entry_point.load(),

--- a/src/pycmor/core/utils.py
+++ b/src/pycmor/core/utils.py
@@ -8,8 +8,8 @@ import os
 import tempfile
 import time
 from functools import partial
-
 from importlib.metadata import entry_points
+
 import requests
 
 from .logging import logger

--- a/src/pycmor/core/utils.py
+++ b/src/pycmor/core/utils.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from functools import partial
 
-import pkg_resources
+from importlib.metadata import entry_points
 import requests
 
 from .logging import logger
@@ -105,7 +105,7 @@ def get_entrypoint_by_name(name, group="pycmor.steps"):
     if group == "pycmor.steps":
         groups_to_try.append("pymor.steps")  # legacy fallback
     for grp in groups_to_try:
-        for entry_point in pkg_resources.iter_entry_points(group=grp):
+        for entry_point in entry_points(group=grp):
             if entry_point.name == name:
                 return entry_point.load()
 


### PR DESCRIPTION
## Summary

- Replace `import pkg_resources` with `from importlib.metadata import entry_points` in `src/pycmor/cli.py` and `src/pycmor/core/utils.py`
- Switch all `pkg_resources.iter_entry_points(group=...)` calls to the stdlib equivalent `entry_points(group=...)`

## Motivation

`pkg_resources` (from `setuptools`) is no longer bundled by default in modern Python environments, causing CI to fail on all Python versions with `ModuleNotFoundError: No module named 'pkg_resources'`. `importlib.metadata` is stdlib since Python 3.9 and covers this use case cleanly.

## Test plan

- [ ] CI passes the "Test if data will work (Meta-Test)" step on all Python versions (3.9, 3.10, 3.11, 3.12)
- [ ] CLI entry point discovery still works correctly

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)